### PR TITLE
Implemented function to load a dicom series into memory as a numpy-array

### DIFF
--- a/prediction/requirements/base.txt
+++ b/prediction/requirements/base.txt
@@ -1,2 +1,4 @@
+dicom_numpy==0.1.1
 Flask==0.12.2
+numpy==1.13.1
 pydicom==0.9.9

--- a/prediction/src/preprocess/errors.py
+++ b/prediction/src/preprocess/errors.py
@@ -1,0 +1,11 @@
+
+class EmptyDicomSeriesException(Exception):
+    """
+    Exception that is raised when the given folder does not contain dcm-files.
+    """
+
+    def __init__(self, *args):
+        if not args:
+            args = ('The specified path does not contain dcm-files. Please ensure that '
+                    'the path points to a folder containing a DICOM-series.', )
+        Exception.__init__(self, *args)

--- a/prediction/src/preprocess/load_dicom.py
+++ b/prediction/src/preprocess/load_dicom.py
@@ -1,0 +1,44 @@
+import dicom
+import dicom_numpy
+from glob import glob
+import os
+
+from .errors import EmptyDicomSeriesException
+
+
+def _read_files(file_pattern):
+    try:
+        files = [dicom.read_file(fn) for fn in glob(file_pattern)]
+        if len(files) == 0:
+            raise EmptyDicomSeriesException
+    except dicom.errors.InvalidDicomError as e:
+        print("Exception reading *.dcm-files: ", e)
+        raise e
+    files = sorted(files, key=lambda x: float(x.SliceLocation))
+    return files
+
+
+def _extract_voxel_data(datasets):
+    try:
+        voxel_ndarray, ijk_to_xyz = dicom_numpy.combine_slices(datasets)
+    except dicom_numpy.DicomImportException as e:
+        print("Exception extracting voxel data: ", e)
+        raise e
+    except AttributeError as e:
+        print("Exception extracting voxel data: ", e)
+        raise dicom_numpy.DicomImportException('Invalid dicom.dataset.Dataset among datasets! ', e)
+    return voxel_ndarray
+
+
+def load_dicom(path):
+    """
+    Function that orchestrates the loading of dicom datafiles of a dicom series into a numpy-array.
+
+    :param path: String containing the path to the folder containing the dcm-files of a series.
+    :return: numpy-array containing the 3D-representation of the DICOM-series
+    """
+
+    file_pattern = os.path.join(path, '*.dcm')
+    files = _read_files(file_pattern)
+    dicom_array = _extract_voxel_data(files)
+    return dicom_array

--- a/prediction/src/tests/test_load_dicom.py
+++ b/prediction/src/tests/test_load_dicom.py
@@ -1,0 +1,47 @@
+import dicom
+import dicom_numpy
+import numpy as np
+import os
+import pytest
+
+from ..preprocess import load_dicom as ld
+from ..preprocess import errors
+
+
+@pytest.fixture
+def dicom_path():
+    return '../images/LIDC-IDRI-0001/1.3.6.1.4.1.14519.5.2.1.6279.6001.298806137288633453246975630178/' \
+           '1.3.6.1.4.1.14519.5.2.1.6279.6001.179049373636438705059720603192'
+
+
+def test_read_files(dicom_path):
+    files = ld._read_files(os.path.join(dicom_path, '*.dcm'))
+
+    assert isinstance(files, list)
+    assert len(files) > 0
+    assert isinstance(files[0], dicom.dataset.Dataset)
+
+    with pytest.raises(dicom.errors.InvalidDicomError):
+        ld._read_files(os.path.join(dicom_path, '*.xml'))
+
+    with pytest.raises(errors.EmptyDicomSeriesException):
+        ld._read_files(os.path.join('./', '*.dcm'))
+
+
+def test_extract_voxel_data(dicom_path):
+    files = ld._read_files(os.path.join(dicom_path, '*.dcm'))
+    dicom_array = ld._extract_voxel_data(files)
+
+    assert isinstance(dicom_array, np.ndarray)
+    assert dicom_array.shape[2] == len(files)
+
+    with pytest.raises(dicom_numpy.DicomImportException):
+        ld._extract_voxel_data([dicom.dataset.Dataset()])
+
+
+def test_load_dicom(dicom_path):
+    dicom_array = ld.load_dicom(dicom_path)
+
+    assert isinstance(dicom_array, np.ndarray)
+    with pytest.raises(errors.EmptyDicomSeriesException):
+        ld.load_dicom('./')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request adds the `load_dicom`-function into `./prediction/src/preprocess` that allows to load a DICOM-series in at a given folder path to be loaded into memory as a numpy-array using the `pydicom` and `dicom_numpy`-packages. The function also reraises exceptions from `pydicom` and `dicom_numpy` in case of corrupt DICOM-files or raises a `EmptyDicomSeriesException` implemented in `./prediction/src/preprocess.errors.py` if the give folder does not contain `*.dcm`-files. More extensive error handling might be necessary in later development stages.

## Reference to official issue
<!--- If fixing a bug, there should be an existing issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #12 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If adding a new feature or making improvements not already reflected in an official issue, please reference the relevant sections of the design doc -->
The change allows loading of DICOM-image series into memory for further processing.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Unittests using `pytest` were added at `./prediction/src/tests/test_load_dicom.py`. The tests assure that files are read correctly by `pydicom` and `dicom_numpy` or an exception is raised as well as that the output is a numpy-nd_array with the right number of images in the z-dimension. To be able to run those tests one test case from `./tests/assets` was copied into the `./prediction/src/tests/assets`-folder to be able to reach it using the current docker-configuration. If there is a more elegant solution to this, please tell :-).
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):


## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well