### PR TITLE
Fix incorrect developer documentation link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Contribute now by [grabbing an issue](https://concepttoclinic.drivendata.org/iss
 
  - [Sign up for the challenge](https://concepttoclinic.drivendata.org/login)
  - Find an [open issue](https://concepttoclinic.drivendata.org/issues) you're interested in working on
- - Get your local environment running with the [developer documentation](https://concepttoclinic.drivendata.org/documentation)
+ - Get your local environment running with the [instructions for setting up Docker](https://concept-to-clinic.readthedocs.io/en/latest/developing-locally-docker.html)
+ - Read [Concept to Clinic’s documentation](https://concepttoclinic.drivendata.org/documentation)
  - Submit your [pull request to the GitHub repo](https://github.com/concept-to-clinic/concept-to-clinic/pulls)
 
 If you need any help, [jump into the forums](https://community.drivendata.org/c/concept-to-clinic) and ask away!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed link to point to Docker setup instructions, added another link to the main developer documentation page.

## Reference to official issue
<!--- If fixing a bug, there should be an existing issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #46.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If adding a new feature or making improvements not already reflected in an official issue, please reference the relevant sections of the design doc -->
Documentation fix.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the new links on the rendered MD page.

## Screenshots (if appropriate):


## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well