### PR TITLE
Fix failing static.SmokeTest.test_landing test 

### DIFF
--- a/interface/backend/static/tests.py
+++ b/interface/backend/static/tests.py
@@ -6,4 +6,5 @@ class SmokeTest(TestCase):
     def test_landing(self):
         url = reverse('static:home')
         resp = self.client.get(url)
-        self.assertContains(resp, 'Hello')
+        self.assertContains(resp, 'Concept to Clinic')
+        self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
Fixed a failing test

## Description
Initially, the test asserted existence for `Hello` text from the response. This text was not available or of use as of making this PR. The `index.html` template has a constant structure with `<title>Concept to Clinic<\title>` tag text . In addition, serving the `index.html` template should resolve a status 200 OK which is better for checking if the template was loaded.

## Reference to official issue
Fixes #7 


## Motivation and Context
This will make the tests in the `interface` app pass for `master` branch.


## How Has This Been Tested?
In the development setup using docker. Run:

`sh tests/test_docker.sh`

All tests should pass

## Screenshots (if appropriate):


## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well