### PR TITLE
Add default githooks for tests and flake8

### DIFF
--- a/.githook-pre-commit
+++ b/.githook-pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+# run flake8 on uncommitted and staged python files with changes
+flake8 $(git status -s | grep -E '\.py$' | cut -c 4-)
+# run the tests within the docker
+sh ./tests/test_docker.sh

--- a/docs/developing-locally-docker.md
+++ b/docs/developing-locally-docker.md
@@ -66,6 +66,31 @@ For example, if you are actively developing the prediction app, you could run th
 
 ## Other notes
 
+### Pre-commit hooks
+Git pre-commit hooks are useful tools that run commands before you commit. To enable easier maintainance of style guide and running tests, we implement pre-commit git hook commands that will run every time before you create a commit.
+
+To set it up on your local development repository:
+
+    $ cd concept-to-clinic
+
+Copy the `.githook-pre-commit` file into the `.git/hooks/` folder as `pre-commit` with `-f` flag so that you overwrite any existing `pre-commit` file:
+
+    $ cp -f .githook-pre-commit .git/hooks/pre-commit
+
+Install `flake8` locally for the styling scripts:
+
+    $ pip install flake8 pep8
+
+You are set! The next time you want to commit, styling and testing pre-commit commands will be executed first and if they fail, your commit will not be committed.
+
+If you want to by-pass the pre-commit check, use `--no-verify` flag in your commit:
+
+    $ git commit --no-verify -m "Ignore pre-commit rules"
+
+To check if the created pre-commit hook is working without having to do a commit, you can run from the root of the project:
+
+    $ .git/hooks/pre-commit
+
 ### Detached Mode
 
 If you want to run the stack in detached mode (in the background without console output), use the `-d` argument:


### PR DESCRIPTION
## Description
I have implemented a githook-pre-commit file that has the `flake8` commands for styling and the command to run tests in the docker containers locally.

## Reference to official issue
It meets requirements for #42 

## Motivation and Context

This change will allow developers to run flake8 and tests before creating a commit. Flake8 command currently runs on uncommitted and staged python files with changes. This reduces the number of files that will be checked against before a commit. In case of project-wide checks, it could be done at CI level.

Documentation on how to set this up locally has also been included.

## How Has This Been Tested?
* Remove any existing `pre-commit` files in `.git/hooks` folder i.e. `rm .git/hooks/pre-commit`
* Copy the .githooks-pre-commit file into `.git/hooks/` as `pre-commit`
* Make it executable using `chmod +x .git/hooks/pre-commit`
* Run `.git/hooks/pre-commit` to test the commands
* Make a change in the code base, add and commit it. It should run `flake8` and run the tests before committing. If the commands pass, the commit is created otherwise it is not.
**Note:**  the tests will fail from the current master branch due to #50 . If you patch your code with https://github.com/concept-to-clinic/concept-to-clinic/pull/50 it should pass all tests

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well