### PR TITLE
#8 Add Sphinx Autodoc 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ prediction/data/*
 
 # ignore data
 data/
+
+# ignore Sphinx apidoc
+_apidoc_*

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,6 +7,10 @@ SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = ConcepttoClinic
 SOURCEDIR     = .
 BUILDDIR      = _build
+APIDOCDIR_INTERFACE    = _apidoc_interface
+APIDOCDIR_PREDICTION   = _apidoc_prediction
+SPHINXAPIDOC  = sphinx-apidoc
+PROJDIR       = ../
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -18,3 +22,12 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: html
+html:
+	$(SPHINXAPIDOC) -f -o $(APIDOCDIR_INTERFACE)/ $(PROJDIR)/interface/
+	$(SPHINXAPIDOC) -f -o $(APIDOCDIR_PREDICTION)/ $(PROJDIR)/prediction/
+	@echo
+	@echo "apidoc build finished. The api source files are in $(APIDOCDIR)/"
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@echo "Sphinx build finished. The build files are in $(BUILDDIR)/"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,16 +45,7 @@ extensions = [
 ]
 
 napoleon_google_docstring = True
-napoleon_numpy_docstring = True
-napoleon_include_init_with_doc = False
-napoleon_include_private_with_doc = False
-napoleon_include_special_with_doc = True
-napoleon_use_admonition_for_examples = False
-napoleon_use_admonition_for_notes = False
-napoleon_use_admonition_for_references = False
-napoleon_use_ivar = False
-napoleon_use_param = True
-napoleon_use_rtype = True
+napoleon_numpy_docstring = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,15 +20,14 @@
 import os
 import sys
 
-DOCS_DIR = os.path.abspath(__file__)
-PROJECT_DIR = os.path.join(DOCS_DIR, os.path.pardir)
+DOCS_DIR = os.getcwd()
+PROJECT_DIR = os.path.abspath(os.path.join(DOCS_DIR, os.pardir))
 
 INTERFACE_DIR = os.path.join(PROJECT_DIR, 'interface')
 sys.path.insert(0, INTERFACE_DIR)
 
 PREDICTION_DIR = os.path.join(PROJECT_DIR, 'prediction')
 sys.path.insert(0, PREDICTION_DIR)
-
 
 # -- General configuration ------------------------------------------------
 
@@ -41,8 +40,21 @@ sys.path.insert(0, PREDICTION_DIR)
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.doctest'
+    'sphinx.ext.doctest',
+    'sphinx.ext.napoleon',
 ]
+
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = False
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,15 @@ Welcome to Concept to Clinic's documentation!
    code-of-conduct-link
    contributor-license-agreement-link
 
+Code
+====
+.. toctree::
+   :maxdepth: 2
+
+   _apidoc_interface/modules
+   _apidoc_prediction/modules
+
+
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ Welcome to Concept to Clinic's documentation!
 
 .. toctree::
    :maxdepth: 4
-   :caption: Developer documentation
+   :caption: Developer Documentation
 
    contribute
    project-structure
@@ -28,10 +28,10 @@ Welcome to Concept to Clinic's documentation!
    code-of-conduct-link
    contributor-license-agreement-link
 
-Code
-====
+
 .. toctree::
    :maxdepth: 2
+   :caption: Code Documentation
 
    _apidoc_interface/modules
    _apidoc_prediction/modules


### PR DESCRIPTION
## Description
This pull request should add the ability to auto-generate code documentation based on Google-styled docstrings. 

## Reference to official issue
This should solve #8 

## Motivation and Context
Instead of manually adapting the documentation to the written code and its docstrings, we can now auto-generate the Sphinx documentation based on the docstrings in the code.

## How Has This Been Tested?
1. I merged my code into #55 (so it's easier for me to update the documentation :-) )
2. I started docker-compose
3. I saw the auto-summaries of all modules, classes and methods that have proper docstrings
4. To confirm that it really supports Google-style docstrings, I downloaded [this](http://www.sphinx-doc.org/en/stable/ext/example_google.html) sample code having lots of Google-docstrings
5. I restarted docker-compose
6. I confirmed that the docstrings of that file were added to the Sphinx documentation

## Screenshots (if appropriate):
Overview
![screenshot from 2017-08-22 01-12-20](https://user-images.githubusercontent.com/6676439/29541838-16715f5e-86d7-11e7-959d-d0877003cfd3.png)
Details of the interface.backend package
![screenshot from 2017-08-22 01-12-35](https://user-images.githubusercontent.com/6676439/29541847-22af0bd6-86d7-11e7-95db-32e346dd851d.png)
One legacy method that already has a complete docstring
![screenshot from 2017-08-22 01-13-10](https://user-images.githubusercontent.com/6676439/29541863-3cad0f7e-86d7-11e7-8cd1-4eb6bd03e03a.png)
The Google-docstring file I added for testing purposes was rendered correctly
![screenshot from 2017-08-22 01-04-16](https://user-images.githubusercontent.com/6676439/29541817-e63bf164-86d6-11e7-97f0-96e87bd7a074.png)

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well