### PR TITLE
doc for git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@ prediction/src/algorithms/identify/assets/ filter=lfs diff=lfs merge=lfs -text
 prediction/src/algorithms/classify/assets/ filter=lfs diff=lfs merge=lfs -text
 prediction/src/algorithms/segment/assets/ filter=lfs diff=lfs merge=lfs -text
 *.dcm filter=lfs diff=lfs merge=lfs -text
+prediction/src/algorithms/classify/assets/* filter=lfs diff=lfs merge=lfs -text
+test/assets/* filter=lfs diff=lfs merge=lfs -text

--- a/docs/configure git-lfs.md
+++ b/docs/configure git-lfs.md
@@ -1,0 +1,109 @@
+As per the documentation in https://github.com/git-lfs/git-lfs/wiki/Tutorial, following steps are outlined.
+
+
+=============================================================================
+install git-lfs
+
+-  Debian
+
+Debian 7 Wheezy and similar needs to have the backports repo installed to get git >= 1.8.2
+
+echo 'deb http://http.debian.net/debian wheezy-backports main' > /etc/apt/sources.list.d/wheezy-backports-main.list
+curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
+sudo apt-get install git-lfs
+git lfs install
+
+-  Mac OSX
+
+You may need to brew update to get all the new formulas
+brew install git-lfs
+git lfs install
+
+-  RHEL/CentOS
+
+Install git >= 1.8.2
+
+Recommended method for RHEL/CentOS 5 and 7 (not 6!)
+
+Install the epel repo link (For CentOS it's just sudo yum install epel-release)
+sudo yum install git
+Recommended method for RHEL/CentOS 6
+
+Install the IUS Community repo. curl -s https://setup.ius.io/ | sudo bash or here
+sudo yum install git2u
+You can also build git from source and install it. If you do that, you will need to either manually download the the git-lfs rpm and install it with rpm -i --nodeps git-lfs*.rpm, or just use the Other instructions. The only other advanced way to fool yum is to create and install a fake/real git rpm to satisfy the git >= 1.8.2 requirement.
+
+To install the git-lfs repo, run curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | sudo bash from here
+
+sudo yum install git-lfs
+
+git lfs install
+
+-  Ubuntu
+
+Similar to Debian 7, Ubuntu 12 and similar Wheezy versions need to have a PPA repo installed to get git >= 1.8.2
+
+sudo apt-get install software-properties-common to install add-apt-repository (or sudo apt-get install python-software-properties if you are on Ubuntu <= 12.04)
+sudo add-apt-repository ppa:git-core/ppa
+The curl script below calls apt-get update, if you aren't using it, don't forget to call apt-get update before installing git-lfs.
+curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
+sudo apt-get install git-lfs
+git lfs install
+
+-  Windows
+
+Download the windows installer from here
+Run the windows installer
+Start a command prompt/or git for windows prompt and run git lfs install
+Docker Recipes
+
+- For Debian Distros, you can use
+
+RUN build_deps="curl ca-certificates" && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${build_deps} && \
+    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git-lfs && \
+    git lfs install && \
+    DEBIAN_FRONTEND=noninteractive apt-get purge -y --auto-remove ${build_deps} && \
+    rm -r /var/lib/apt/lists/*
+
+-  Other
+
+To install on any supported operating system, manually install git-lfs with no man pages.
+
+Only one file is required for git-lfs, the git-lfs binary. i386 and x86_64 versions are available here for FreeBSD, Linux, Mac and Windows. Currently, linux arm6 must be compiled from source
+
+Install git version 1.8.2 or newer
+Download and put the git-lfs (.exe for windows) in your path, and git lfs commands start working, as long as both git and git-lfs are in your path.
+Source
+
+Get go. Either use your OS repo or get it here. For best results, use latest stable go to get all the patches
+git clone https://github.com/github/git-lfs.git
+In the git-lfs directory, run ./script/bootstrap
+The git-lfs binary should appear in the ./bin directory
+Alternatively, you can use go to
+
+go get github.com/github/git-lfs
+$GOPATH/bin/
+Edit/checkout $GOPATH/src/github.com/github/git-lfs and run go build github.com/github/git-lfs if needed
+
+=============================================================================
+setup git-lfs with this project
+
+To the current directory of your clones local repo of the concept-to-clinic.
+Then execute the following commands.
+-   git add .gitattributes
+
+
+=============================================================================
+decide to track files with git-lfs and remove those files from the repo
+
+- git lfs track "prediction/src/algorithms/classify/assets/*"
+- git lfs track "test/assets/*"
+
+=============================================================================
+
+not use git-lfs (for example, to save on bandwidth) and pull the repo without the large files
+
+- git lfs pull


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is a documentation about the installation of git lifs in the current project and how it can be used. I have referred to the git tutorials for the different platforms on ehich git lfs can be installed and can be used to refer the large images in a different server without they been present in the code repo.

## Description
<!--- Describe your changes in detail -->
All the diff platforms Mac, Windiws, Linux, Rhel/CentOS, Debian are mentioned.
The image files which are referred are present in the .gitattributes file as below:
_prediction/src/algorithms/identify/assets/ filter=lfs diff=lfs merge=lfs -text
prediction/src/algorithms/classify/assets/ filter=lfs diff=lfs merge=lfs -text
prediction/src/algorithms/segment/assets/ filter=lfs diff=lfs merge=lfs -text
*.dcm filter=lfs diff=lfs merge=lfs -text
prediction/src/algorithms/classify/assets/* filter=lfs diff=lfs merge=lfs -text
test/assets/* filter=lfs diff=lfs merge=lfs -text_

## Reference to official issue
<!--- If fixing a bug, there should be an existing issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If adding a new feature or making improvements not already reflected in an official issue, please reference the relevant sections of the design doc -->
https://github.com/concept-to-clinic/concept-to-clinic/issues/16 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

git lifs env (in my local)
Endpoint=https://github.com/doel/concept-to-clinic.git/info/lfs (auth=basic)
LocalWorkingDir=/Users/doelsengupta/Documents/GitHub/concept-to-clinic
LocalGitDir=/Users/doelsengupta/Documents/GitHub/concept-to-clinic/.git
LocalGitStorageDir=/Users/doelsengupta/Documents/GitHub/concept-to-clinic/.git
LocalMediaDir=/Users/doelsengupta/Documents/GitHub/concept-to-clinic/.git/lfs/objects
LocalReferenceDir=
TempDir=/Users/doelsengupta/Documents/GitHub/concept-to-clinic/.git/lfs/tmp
ConcurrentTransfers=3
TusTransfers=false
BasicTransfersOnly=false
SkipDownloadErrors=false
FetchRecentAlways=false
FetchRecentRefsDays=7
FetchRecentCommitsDays=0
FetchRecentRefsIncludeRemotes=true
PruneOffsetDays=3
PruneVerifyRemoteAlways=false
PruneRemoteName=origin
AccessDownload=basic
AccessUpload=basic
DownloadTransfers=basic
UploadTransfers=basic
git config filter.lfs.process = "git-lfs filter-process"
git config filter.lfs.smudge = "git-lfs smudge -- %f"
git config filter.lfs.clean = "git-lfs clean -- %f"

<!--- Include details of your testing environment, and the tests you ran to -->

All the tests were run in my local env, after cloning the repo locally.

<!--- see how your change affects other areas of the code, etc. -->
After pulling with git lfs option enabled, the large images won't be pulled and only their reference will be there.

## Screenshots (if appropriate):


## CLA
- [ ] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well

coudln't find any place to sign the CLA
<img width="647" alt="screen shot 2017-08-21 at 10 59 44 pm" src="https://user-images.githubusercontent.com/427998/29548463-aff7b33c-86c6-11e7-9548-2ec433d33023.png">
