### PR TITLE
Self-documenting endpoint

### DIFF
--- a/prediction/src/tests/test_endpoints.py
+++ b/prediction/src/tests/test_endpoints.py
@@ -11,6 +11,9 @@ import pytest
 
 from flask import url_for
 from src.factory import create_app
+from src.algorithms import classify
+from src.algorithms import identify
+from src.algorithms import segment
 
 
 def get_data(response):
@@ -48,10 +51,22 @@ def test_endpoint_documentation(client):
     r = client.get(url)
     data = get_data(r)
 
-    assert 'description' in data
+    assert data['description'] == identify.trained_model.predict.__doc__
+
+    url = client.url_for('predict', algorithm='segment')
+    r = client.get(url)
+    data = get_data(r)
+
+    assert data['description'] == segment.trained_model.predict.__doc__
+
+    url = client.url_for('predict', algorithm='classify')
+    r = client.get(url)
+    data = get_data(r)
+
+    assert data['description'] == classify.trained_model.predict.__doc__
 
 
-def test_indentify(client):
+def test_identify(client):
     url = client.url_for('predict', algorithm='identify')
 
     test_data = dict(dicom_path='')

--- a/prediction/src/tests/test_endpoints.py
+++ b/prediction/src/tests/test_endpoints.py
@@ -11,9 +11,7 @@ import pytest
 
 from flask import url_for
 from src.factory import create_app
-from src.algorithms import classify
-from src.algorithms import identify
-from src.algorithms import segment
+from src.algorithms import classify, identify, segment
 
 
 def get_data(response):
@@ -47,23 +45,17 @@ def test_home(client):
 
 
 def test_endpoint_documentation(client):
-    url = client.url_for('predict', algorithm='identify')
-    r = client.get(url)
-    data = get_data(r)
+    docstrings = {
+        'identify': identify.trained_model.predict.__doc__,
+        'segment': segment.trained_model.predict.__doc__,
+        'classify': classify.trained_model.predict.__doc__
+    }
 
-    assert data['description'] == identify.trained_model.predict.__doc__
-
-    url = client.url_for('predict', algorithm='segment')
-    r = client.get(url)
-    data = get_data(r)
-
-    assert data['description'] == segment.trained_model.predict.__doc__
-
-    url = client.url_for('predict', algorithm='classify')
-    r = client.get(url)
-    data = get_data(r)
-
-    assert data['description'] == classify.trained_model.predict.__doc__
+    for algorithm in ['identify', 'segment', 'classify']:
+        url = client.url_for('predict', algorithm=algorithm)
+        r = client.get(url)
+        data = get_data(r)
+        assert data['description'] == docstrings[algorithm]
 
 
 def test_identify(client):

--- a/prediction/src/views.py
+++ b/prediction/src/views.py
@@ -70,7 +70,7 @@ def predict(algorithm):
     # describe API on GET
     elif request.method == 'GET':
         response.update({
-            'description': 'API documentation goes here.',
+            'description': PREDICTORS[algorithm].__doc__,
         })
 
     # make predictions on POST


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a very simple fix, I simply changed the endpoint to return the *docstring* of the selected `predict` function. Personally, I think this is the best way to keep it "self-documenting" and keeping the description in one place only. Let me know if you have problems with this approach.

Also, I added an `__init__.py` file to the `algorithms` folder to make it a valid Python package.
## Reference to official issue
<!--- If fixing a bug, there should be an existing issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#10 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Modified the `test_endpoint_documentation` test to make sure that calls return the appropriate docstring.


## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well