### PR TITLE
Improve error handling in prediction API

### DIFF
--- a/prediction/src/algorithms/classify/trained_model.py
+++ b/prediction/src/algorithms/classify/trained_model.py
@@ -7,6 +7,8 @@
     for if nodules are concerning or not.
 """
 
+from src.preprocess.load_dicom import load_dicom
+
 
 def predict(dicom_path, centroids):
     """ Predicts if centroids are concerning or not.
@@ -33,6 +35,7 @@ def predict(dicom_path, centroids):
              'z': int,
              'p_concerning': float}
     """
+    load_dicom(dicom_path)
     for centroid in centroids:
         centroid['p_concerning'] = 0.5
 

--- a/prediction/src/algorithms/identify/trained_model.py
+++ b/prediction/src/algorithms/identify/trained_model.py
@@ -7,6 +7,8 @@
     for where the centroids of nodules are in the DICOM image.
 """
 
+from src.preprocess.load_dicom import load_dicom
+
 
 def predict(dicom_path):
     """ Predicts centroids of nodules in a DICOM image.
@@ -32,6 +34,7 @@ def predict(dicom_path):
              'z': int,
              'p_nodule': float}
     """
+    load_dicom(dicom_path)
     return [{'x': 0,
              'y': 0,
              'z': 0,

--- a/prediction/src/algorithms/segment/trained_model.py
+++ b/prediction/src/algorithms/segment/trained_model.py
@@ -7,6 +7,8 @@
     descriptive statistics.
 """
 
+from src.preprocess.load_dicom import load_dicom
+
 
 def predict(dicom_path, centroids):
     """ Predicts nodule boundaries.
@@ -32,6 +34,7 @@ def predict(dicom_path, centroids):
             {'binary_mask_path': str,
              'volumes': list[float]}
     """
+    load_dicom(dicom_path)
     segment_path = 'path/to/segmentation'
     volumes = calculate_volume(segment_path, centroids)
     return_value = {

--- a/prediction/src/views.py
+++ b/prediction/src/views.py
@@ -57,14 +57,15 @@ def predict(algorithm):
         algorithm (str): The prediction algorithm to use. One of 'segment',
             'classify', or 'identify'.
     """
-    # empty string to track if there was an
-    error = ''
 
     # dictionary to hold the response
     response = dict()
 
+    # string to contain error message
+    error = ""
+
     if algorithm not in PREDICTORS:
-        errormsg = 'Error! {} is not a valid algorithm. Please choose from {}.'
+        errormsg = "Error! '{}' is not a valid algorithm. Please choose from {}."
         error = errormsg.format(algorithm, set(PREDICTORS))
 
     # describe API on GET
@@ -84,17 +85,19 @@ def predict(algorithm):
             prediction = predict_method(**payload)
 
             response.update({
-                'prediction': prediction
+                'prediction': prediction,
             })
 
-        except Exception:
-            error = "There was an error with your request."
+        except Exception as e:
+            # pass errors from prediction function along with function chosen
+            error = "Error using algorithm '{}': {} ({})."
+            error = error.format(algorithm, str(e), type(e).__name__)
 
-    # set the status code and messages for the response
+    # set the status code for the response
     if error:
         response.update({
             'error': error,
-            'status': 500
+            'status': 500,
         })
     else:
         response.update({


### PR DESCRIPTION
Prediction API now returns message specifying if a needed parameter is not
passed to the prediction algorithm, and passes error messages that occur within
the prediction algorithm.

## Description
The API passes an error message if a non-existent algorithm is selected, as before. The API now also passes an error message if a necessary parameter to the algorithm is missing, specifying the algorithm chosen and the required parameter.  All other errors (e.g., bad DICOM file path) should be caught within the prediction algorithm, and these messages are caught and passed through the API.

## Reference to official issue
Fixes issue #11 

## How Has This Been Tested?
These changes are tested through additional tests in test_endpoints.py. To properly test the response to bad DICOM paths, I modified the "predict" functions of the three "trained_model.py" modules to load the passed DICOM path. This loaded image is currently simply discarded after loading.

## Screenshots (if appropriate):


## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well