### PR TITLE
#29 Show current Git version in top-level navigation

### DIFF
--- a/interface/backend/static/urls.py
+++ b/interface/backend/static/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
-from django.views.generic import TemplateView
+from . import views
 
 urlpatterns = (
-    url(r'^$', TemplateView.as_view(template_name='index.html'), name='home'),
+    url(r'^$', views.home, name='home'),
 )

--- a/interface/backend/static/views.py
+++ b/interface/backend/static/views.py
@@ -1,0 +1,7 @@
+from django.shortcuts import render
+
+
+def home(request):
+    current_hash = open('/HEAD', 'r').readlines()[-1].split(' ')[1]
+    short_hash = current_hash[:7]
+    return render(request, '../frontend/index.html', {'short_hash': short_hash})

--- a/interface/backend/static/views.py
+++ b/interface/backend/static/views.py
@@ -1,7 +1,6 @@
+from django.conf import settings
 from django.shortcuts import render
 
 
 def home(request):
-    current_hash = open('/HEAD', 'r').readlines()[-1].split(' ')[1]
-    short_hash = current_hash[:7]
-    return render(request, '../frontend/index.html', {'short_hash': short_hash})
+    return render(request, '../frontend/index.html', {'short_hash': settings.APP_VERSION_NUMBER})

--- a/interface/config/settings/base.py
+++ b/interface/config/settings/base.py
@@ -124,3 +124,9 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.AllowAny'
     ]
 }
+
+try:
+    with open('/HEAD') as f:
+        APP_VERSION_NUMBER = f.readlines()[-1].split(' ')[1][:7]
+except:
+    APP_VERSION_NUMBER = '(unknown)'

--- a/interface/frontend/index.html
+++ b/interface/frontend/index.html
@@ -10,6 +10,10 @@
         integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous"/>
 </head>
 <body>
+
+<div class="col-12 col-md-2 float-md-right">
+  Version: {{ short_hash }}
+</div>
 {% verbatim %}
 <div class="container">
   <div id="app">

--- a/local.yml
+++ b/local.yml
@@ -28,6 +28,7 @@ services:
     volumes:
       - ./interface/:/app
       - ./tests/assets/test_image_data/small:/images
+      - ./.git/logs/HEAD:/HEAD
     ports:
       - "8000:8000"
 


### PR DESCRIPTION
For debugging purposes it would be really nice to see in the top right corner which version is currently used. The version is the short SHA-1 commit hash.

## Description
Since I didn't want to add the whole `.git` directory to the Docker container, I just added `.git/logs/HEAD` as a volume which contains historical information about branch changes etc. 


## Reference to official issue
This should solve #29 


## Motivation and Context
The big advantage is that by just adding `HEAD` we don't have the full Git history in our container. Furthermore, every time we switch branches or commit, the `HEAD` file is synchronized with the container (as well as the Docker volumes). In the container, a Django view parses the short current commit hash out of that file and displays it. This way, when switching branches not only the code in the container is synchronized with the code at the host but also the commit hash is updated accordingly. The container can then also be deployed to production.

## How Has This Been Tested?
1. `docker-compose -f local.yml up`  yields
![screenshot from 2017-08-24 23-11-18](https://user-images.githubusercontent.com/6676439/29688898-94e29b54-8921-11e7-804e-95e81144959d.png)

(with the short version of the commit of this branch: a9f0e6a)
2. add an empty commit: `git commit -m "l" --allow-empty`
3. I refreshed the page and ended up with
![screenshot from 2017-08-24 23-12-13](https://user-images.githubusercontent.com/6676439/29688923-b009ea54-8921-11e7-8944-6e408e371950.png)
which was the short version of the commit hash of the empty commit (1bd5c33)

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well