### PR TITLE
Compute tumor volume from binary mask and list of centroids

### DIFF
--- a/prediction/requirements/base.txt
+++ b/prediction/requirements/base.txt
@@ -2,3 +2,4 @@ dicom_numpy==0.1.1
 Flask==0.12.2
 numpy==1.13.1
 pydicom==0.9.9
+scipy=0.19.1

--- a/prediction/requirements/base.txt
+++ b/prediction/requirements/base.txt
@@ -2,4 +2,4 @@ dicom_numpy==0.1.1
 Flask==0.12.2
 numpy==1.13.1
 pydicom==0.9.9
-scipy=0.19.1
+scipy==0.19.1

--- a/prediction/src/algorithms/segment/trained_model.py
+++ b/prediction/src/algorithms/segment/trained_model.py
@@ -2,9 +2,12 @@
 """
     algorithms.segment.trained_model
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
     An API for a trained segmentation model to predict nodule boundaries and
     descriptive statistics.
 """
+
+
 import numpy as np
 import os
 import scipy.ndimage

--- a/prediction/src/algorithms/segment/trained_model.py
+++ b/prediction/src/algorithms/segment/trained_model.py
@@ -2,15 +2,16 @@
 """
     algorithms.segment.trained_model
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
     An API for a trained segmentation model to predict nodule boundaries and
     descriptive statistics.
 """
+import numpy as np
+import os
+import scipy.ndimage
 
 
 def predict(dicom_path, centroids):
     """ Predicts nodule boundaries.
-
     Given a pth to a DICOM image and a list of centroids
         (1) load the segmentation model from its serialized state
         (2) pre-process the dicom data into whatever format the segmentation
@@ -18,14 +19,12 @@ def predict(dicom_path, centroids):
         (3) for each pixel create an indicator 0 or 1 of if the pixel is
             cancerous
         (4) write this binary mask to disk, and return the path to the mask
-
     Args:
         dicom_path (str): a path to a DICOM directory
         centroids (list[dict]): A list of centroids of the form::
             {'x': int,
              'y': int,
              'z': int}
-
     Returns:
         dict: Dictionary containing path to serialized binary masks and
             volumes per centroid with form::
@@ -41,18 +40,43 @@ def predict(dicom_path, centroids):
     return return_value
 
 
-def calculate_volume(segment_path, centroids):
-    """ Calculates tumor volume from pixel masks
+def calculate_volume(segment_path, centroids, voxel_shape=1.):
+    """ Calculates tumor volume.
+
+    Given the path to the serialized mask and a list of centroids
+        (1) For each centroid, calculate the volume of the tumor.  
+        (2) DICOM has voxels' sizes in mm therefore the volume should be in real 
+        measurements (not pixels).
 
     Args:
-        segment_path (str): A path to the serialized binary mask for
-            each centroid
+        segment_path (str): a path to a mask file
         centroids (list[dict]): A list of centroids of the form::
             {'x': int,
              'y': int,
              'z': int}
+        voxel_shape (float | list[float]): The voxels' sizes along the axes. 
+            If a float, `voxel_shape` is the same for each axis. 
+            If a sequence, `voxel_shape` should contain one value for each axis.
 
+    Raises: 
+        TypeError, ValueError
+            
     Returns:
-        list[float]: List of volumes per centroid
+        list[float]: a list of volumes of a connected component for each centroid
     """
-    return [0.5 for centroid in centroids]
+
+    if not (isinstance(voxel_shape, float) or isinstance(voxel_shape, list)):
+        raise TypeError('Type of voxel_shape should be float or list of floats.')
+
+    try:
+        mask = np.load(segment_path)
+    except:
+        raise ValueError('The segment_path must be a path to a numpy array.')        
+
+        
+    voxel_shape = scipy.ndimage._ni_support._normalize_sequence(voxel_shape, mask.ndim)
+    mask, _ = scipy.ndimage.label(mask)
+    labels = [mask[centroid['x'], centroid['y'], centroid['z']] for centroid in centroids]
+    volumes = np.bincount(mask.flatten())
+    volumes = volumes[labels] * np.prod(voxel_shape)
+    return volumes.tolist()

--- a/prediction/src/tests/test_trumor_volume.py
+++ b/prediction/src/tests/test_trumor_volume.py
@@ -32,7 +32,7 @@ def test_calculate_volume_on_unoverlapped_connected_components():
     path = os.path.join('.', 'tmp', 'mask.npy')
     if not os.path.exists(os.path.dirname(path)):
         os.makedirs(os.path.dirname(path))
-#   The balls modelled to be not overlapped 
+    #   The balls modelled to be not overlapped 
     np.save(path, mask)
     assert os.path.exists(path)
     
@@ -47,7 +47,7 @@ def test_calculate_volume_on_overlapped_connected_components():
     centroids = [[0, 0, 0], [0, 0, 0], [45, 45, 12]]
     centroids = [{'x': centroid[0], 'y': centroid[1], 'z': centroid[2]} for centroid in centroids]
     mask = generate_mask(shape=[50, 50, 29], centroids=centroids, volumes=[100, 20, 30])
-#   The balls area must be 100 + 30, since first ball have overlapped with the second one
+    #   The balls area must be 100 + 30, since first ball have overlapped with the second one
     assert mask.sum() == 130
     
     path = os.path.join('.', 'tmp', 'mask.npy')
@@ -58,12 +58,12 @@ def test_calculate_volume_on_overlapped_connected_components():
     assert os.path.exists(path)
     
     volumes_calculated = trained_model.calculate_volume(path, centroids, voxel_shape=[1., 1., 1.])
-#   Despite they are overlapped, the amount of volumes must have preserved
+    #   Despite they are overlapped, the amount of volumes must have preserved
     assert len(volumes_calculated) == 3
     assert volumes_calculated == [100, 100, 30]
     
     volumes_calculated = trained_model.calculate_volume(path, centroids, voxel_shape=[.5, 1., 1.5])
-#   Despite they are overlapped, the amount of volumes must have preserved
+    #   Despite they are overlapped, the amount of volumes must have preserved
     assert len(volumes_calculated) == 3
     assert volumes_calculated == [75., 75., 22.5]
     shutil.rmtree(os.path.dirname(path))

--- a/prediction/src/tests/test_trumor_volume.py
+++ b/prediction/src/tests/test_trumor_volume.py
@@ -67,3 +67,4 @@ def test_calculate_volume_on_overlapped_connected_components():
     assert len(volumes_calculated) == 3
     assert volumes_calculated == [75., 75., 22.5]
     shutil.rmtree(os.path.dirname(path))
+    

--- a/prediction/src/tests/test_trumor_volume.py
+++ b/prediction/src/tests/test_trumor_volume.py
@@ -67,4 +67,3 @@ def test_calculate_volume_on_overlapped_connected_components():
     assert len(volumes_calculated) == 3
     assert volumes_calculated == [75., 75., 22.5]
     shutil.rmtree(os.path.dirname(path))
-    

--- a/prediction/src/tests/test_trumor_volume.py
+++ b/prediction/src/tests/test_trumor_volume.py
@@ -1,0 +1,69 @@
+import numpy as np
+import os
+import pytest
+import shutil
+
+from ..algorithms.segment import trained_model
+
+
+@pytest.fixture
+def generate_motes(mask, centroid, volume):
+    centroid_ = np.asarray([centroid['x'], centroid['y'], centroid['z']])
+    free_voxels = np.where(mask != -1)
+    free_voxels = np.asarray(free_voxels).T
+    free_voxels = sorted(free_voxels, key=lambda x: np.linalg.norm(x - centroid_, ord=2))
+    free_voxels = np.asarray(free_voxels[:volume]).T
+    mask[(free_voxels[0], free_voxels[1], free_voxels[2])] = True
+    
+
+def generate_mask(shape, centroids, volumes):
+    mask = np.zeros(shape, dtype=np.bool_)
+    for centroid, volume in zip(centroids, volumes):
+        generate_motes(mask, centroid, volume)
+    return mask
+    
+
+def test_calculate_volume_on_unoverlapped_connected_components():
+    centroids = [[0, 0, 0], [32, 32, 28], [45, 45, 12]]
+    centroids = [{'x': centroid[0], 'y': centroid[1], 'z': centroid[2]} for centroid in centroids]
+    mask = generate_mask(shape=[50, 50, 29], centroids=centroids, volumes=[100, 20, 30])
+    assert mask.sum() == 150
+
+    path = os.path.join('.', 'tmp', 'mask.npy')
+    if not os.path.exists(os.path.dirname(path)):
+        os.makedirs(os.path.dirname(path))
+#   The balls modelled to be not overlapped 
+    np.save(path, mask)
+    assert os.path.exists(path)
+    
+    volumes_calculated = trained_model.calculate_volume(path, centroids, voxel_shape=[1., 1., 1.])
+    assert len(volumes_calculated) == 3
+    assert volumes_calculated == [100, 20, 30]    
+    shutil.rmtree(os.path.dirname(path))
+    
+
+
+def test_calculate_volume_on_overlapped_connected_components():
+    centroids = [[0, 0, 0], [0, 0, 0], [45, 45, 12]]
+    centroids = [{'x': centroid[0], 'y': centroid[1], 'z': centroid[2]} for centroid in centroids]
+    mask = generate_mask(shape=[50, 50, 29], centroids=centroids, volumes=[100, 20, 30])
+#   The balls area must be 100 + 30, since first ball have overlapped with the second one
+    assert mask.sum() == 130
+    
+    path = os.path.join('.', 'tmp', 'mask.npy')
+
+    if not os.path.exists(os.path.dirname(path)):
+        os.makedirs(os.path.dirname(path))
+    np.save(path, mask)
+    assert os.path.exists(path)
+    
+    volumes_calculated = trained_model.calculate_volume(path, centroids, voxel_shape=[1., 1., 1.])
+#   Despite they are overlapped, the amount of volumes must have preserved
+    assert len(volumes_calculated) == 3
+    assert volumes_calculated == [100, 100, 30]
+    
+    volumes_calculated = trained_model.calculate_volume(path, centroids, voxel_shape=[.5, 1., 1.5])
+#   Despite they are overlapped, the amount of volumes must have preserved
+    assert len(volumes_calculated) == 3
+    assert volumes_calculated == [75., 75., 22.5]
+    shutil.rmtree(os.path.dirname(path))


### PR DESCRIPTION
## Description
This method computes the volume of connected components placed at the specified centroids, via connected component analysis using `scipy.ndimage.label`.

## Reference to official issue
Calculate tumor volume from pixel masks [#13](https://github.com/concept-to-clinic/concept-to-clinic/issues/13) 

## How Has This Been Tested?
The unit test for `predict` has been added  to test for the volume calculation over the different mask cases.

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well