### PR TITLE
Calculate tumor volume

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@ tests/assets/test_image_data/small/**/*.dcm -filter=lfs -diff=lfs -merge=lfs -te
 test/assets/* filter=lfs diff=lfs merge=lfs -text
 *.dcm filter=lfs diff=lfs merge=lfs -text
 *.h5 filter=lfs diff=lfs merge=lfs -text
+*.npy filter=lfs diff=lfs merge=lfs -text

--- a/prediction/requirements/base.txt
+++ b/prediction/requirements/base.txt
@@ -2,7 +2,7 @@ dicom_numpy==0.1.1
 Flask==0.12.2
 numpy==1.13.1
 pydicom==0.9.9
-scipy==0.19.1
 keras==2.0.8
 tensorflow==1.3.0
 h5py==2.7.0
+scipy==0.19.1

--- a/prediction/src/algorithms/segment/assets/test_mask.npy
+++ b/prediction/src/algorithms/segment/assets/test_mask.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a51da7d4f48c358cfd5e0902b3af5adc0971787158d0f301043ef0adbce2d696
+size 80

--- a/prediction/src/preprocess/load_dicom.py
+++ b/prediction/src/preprocess/load_dicom.py
@@ -58,3 +58,17 @@ def load_dicom(path, preprocess=None):
                             'callable[list[DICOM], ndarray] -> ndarray')
 
     return voxel_data
+
+
+def load_meta(path):
+    """Function that load a DICOM series.
+
+    Args:
+        path (str): contains the path to the folder containing the dcm-files of a series.
+
+    Returns:
+        DICOM series
+    """
+
+    file_pattern = os.path.join(path, '*.dcm')
+    return read_dicom_files(file_pattern)

--- a/prediction/src/tests/test_calculate_volume.py
+++ b/prediction/src/tests/test_calculate_volume.py
@@ -1,0 +1,69 @@
+import numpy as np
+import pytest
+
+from ..algorithms.segment import trained_model
+
+
+def generate_motes(mask, centroid, volume):
+    centroid_ = np.asarray([centroid['x'], centroid['y'], centroid['z']])
+    free_voxels = np.where(mask != -1)
+    free_voxels = np.asarray(free_voxels).T
+    free_voxels = sorted(free_voxels, key=lambda x: np.linalg.norm(x - centroid_, ord=2))
+    free_voxels = np.asarray(free_voxels[:volume]).T
+    mask[(free_voxels[0], free_voxels[1], free_voxels[2])] = True
+
+
+def generate_mask(shape, centroids, volumes):
+    mask = np.zeros(shape, dtype=np.bool_)
+    for centroid, volume in zip(centroids, volumes):
+        generate_motes(mask, centroid, volume)
+    return mask
+
+
+def test_calculate_volume_over_unconnected_components(tmpdir):
+    centroids = [[0, 0, 0], [32, 32, 28], [45, 45, 12]]
+    centroids = [{'x': centroid[0], 'y': centroid[1], 'z': centroid[2]} for centroid in centroids]
+    mask = generate_mask(shape=[50, 50, 29], centroids=centroids, volumes=[100, 20, 30])
+    # The balls modelled to be not overlapped
+    assert mask.sum() == 150
+
+    path = tmpdir.mkdir("masks").join("mask.npy")
+    np.save(str(path), mask)
+
+    volumes_calculated = trained_model.calculate_volume(str(path), centroids)
+    assert len(volumes_calculated) == 3
+    assert volumes_calculated == [100, 20, 30]
+
+
+@pytest.fixture(scope='session')
+def get_mask_connected(tmpdir_factory):
+    centroids = [[0, 0, 0], [0, 0, 0], [45, 45, 12]]
+    centroids = [{'x': centroid[0], 'y': centroid[1], 'z': centroid[2]} for centroid in centroids]
+    mask = generate_mask(shape=[50, 50, 29], centroids=centroids, volumes=[100, 20, 30])
+    #   The balls area must be 100 + 30, since first ball have overlapped with the second one
+    assert mask.sum() == 130
+
+    path = tmpdir_factory.mktemp("masks").join("mask.npy")
+    np.save(str(path), mask)
+    return path, centroids
+
+
+def test_calculate_volume_over_connected_components(get_mask_connected):
+    path, centroids = get_mask_connected
+    volumes_calculated = trained_model.calculate_volume(str(path), centroids)
+    #   Despite they are overlapped, the amount of volumes must have preserved
+    assert len(volumes_calculated) == 3
+    assert volumes_calculated == [100, 100, 30]
+
+
+def test_calculate_volume_over_connected_components_with_dicom_path(get_mask_connected):
+    path, centroids = get_mask_connected
+    voxels_volumes = [100, 100, 30]
+    dicom_path = '../images/LIDC-IDRI-0001/1.3.6.1.4.1.14519.5.2.1.6279.6001.298806137288633453246975630178/' \
+                 '1.3.6.1.4.1.14519.5.2.1.6279.6001.179049373636438705059720603192'
+    real_volumes = trained_model.calculate_volume(str(path), centroids, dicom_path)
+
+    #   Despite they are overlapped, the amount of volumes must have preserved
+    assert len(real_volumes) == len(voxels_volumes)
+    assert all([1.2360 >= mm / vox >= 1.2358
+                for vox, mm in zip(voxels_volumes, real_volumes)])

--- a/prediction/src/tests/test_load_dicom.py
+++ b/prediction/src/tests/test_load_dicom.py
@@ -28,7 +28,7 @@ def test_read_files(dicom_path):
         ld.read_dicom_files('./not_a_dcm.xml')
 
     with pytest.raises(errors.EmptyDicomSeriesException):
-        ld.read_dicom_files(os.path.join('./', '*.dcm'))
+        ld.read_dicom_files(os.path.join('.', '*.dcm'))
 
 
 def test_extract_voxel_data(dicom_path):
@@ -48,4 +48,10 @@ def test_load_dicom(dicom_path):
     assert isinstance(dicom_array, np.ndarray)
 
     with pytest.raises(errors.EmptyDicomSeriesException):
-        ld.load_dicom('./')
+        ld.load_dicom('.')
+
+
+def test_load_meta(dicom_path):
+    dicom_series = ld.load_meta(dicom_path)
+
+    assert isinstance(dicom_series, list)


### PR DESCRIPTION
## Description
This method computes the volume of connected components placed at the specified centroids, via connected component analysis using `scipy.ndimage.label`. The `voxel_shape` parameter has added to the function in order to derive units of measure. 

## Reference to official issue
Calculate tumor volume from pixel masks [#13](https://github.com/concept-to-clinic/concept-to-clinic/issues/13) 

## How Has This Been Tested?
The unit test for `calculate_volume` has been added to test for the volume calculation over the different mask instances. During the testing, another issue has acquired at `test_segment`, which was related to the meaningless `segment_path`. Hence the changes were also added to the `segment.predict` function.

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well