### PR TITLE
#79 Fix: Code Documentation is not being displayed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,3 @@ prediction/data/*
 
 # ignore data
 data/
-
-# ignore Sphinx apidoc
-_apidoc_*

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,8 +7,8 @@ SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = ConcepttoClinic
 SOURCEDIR     = .
 BUILDDIR      = _build
-APIDOCDIR_INTERFACE    = _apidoc_interface
-APIDOCDIR_PREDICTION   = _apidoc_prediction
+APIDOCDIR_INTERFACE    = apidoc_interface
+APIDOCDIR_PREDICTION   = apidoc_prediction
 SPHINXAPIDOC  = sphinx-apidoc
 PROJDIR       = ../
 

--- a/docs/apidoc_interface/backend.api.rst
+++ b/docs/apidoc_interface/backend.api.rst
@@ -1,0 +1,61 @@
+backend\.api package
+====================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    backend.api.migrations
+
+Submodules
+----------
+
+backend\.api\.apps module
+-------------------------
+
+.. automodule:: backend.api.apps
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+backend\.api\.serializers module
+--------------------------------
+
+.. automodule:: backend.api.serializers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+backend\.api\.tests module
+--------------------------
+
+.. automodule:: backend.api.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+backend\.api\.urls module
+-------------------------
+
+.. automodule:: backend.api.urls
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+backend\.api\.views module
+--------------------------
+
+.. automodule:: backend.api.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: backend.api
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_interface/backend.cases.migrations.rst
+++ b/docs/apidoc_interface/backend.cases.migrations.rst
@@ -1,0 +1,22 @@
+backend\.cases\.migrations package
+==================================
+
+Submodules
+----------
+
+backend\.cases\.migrations\.0001\_initial module
+------------------------------------------------
+
+.. automodule:: backend.cases.migrations.0001_initial
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: backend.cases.migrations
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_interface/backend.cases.rst
+++ b/docs/apidoc_interface/backend.cases.rst
@@ -1,0 +1,53 @@
+backend\.cases package
+======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    backend.cases.migrations
+
+Submodules
+----------
+
+backend\.cases\.apps module
+---------------------------
+
+.. automodule:: backend.cases.apps
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+backend\.cases\.factories module
+--------------------------------
+
+.. automodule:: backend.cases.factories
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+backend\.cases\.models module
+-----------------------------
+
+.. automodule:: backend.cases.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+backend\.cases\.tests module
+----------------------------
+
+.. automodule:: backend.cases.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: backend.cases
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_interface/backend.images.migrations.rst
+++ b/docs/apidoc_interface/backend.images.migrations.rst
@@ -1,0 +1,30 @@
+backend\.images\.migrations package
+===================================
+
+Submodules
+----------
+
+backend\.images\.migrations\.0001\_initial module
+-------------------------------------------------
+
+.. automodule:: backend.images.migrations.0001_initial
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+backend\.images\.migrations\.0002\_imageseries\_patient\_id module
+------------------------------------------------------------------
+
+.. automodule:: backend.images.migrations.0002_imageseries_patient_id
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: backend.images.migrations
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_interface/backend.images.rst
+++ b/docs/apidoc_interface/backend.images.rst
@@ -1,0 +1,53 @@
+backend\.images package
+=======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    backend.images.migrations
+
+Submodules
+----------
+
+backend\.images\.apps module
+----------------------------
+
+.. automodule:: backend.images.apps
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+backend\.images\.factories module
+---------------------------------
+
+.. automodule:: backend.images.factories
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+backend\.images\.models module
+------------------------------
+
+.. automodule:: backend.images.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+backend\.images\.tests module
+-----------------------------
+
+.. automodule:: backend.images.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: backend.images
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_interface/backend.rst
+++ b/docs/apidoc_interface/backend.rst
@@ -1,0 +1,20 @@
+backend package
+===============
+
+Subpackages
+-----------
+
+.. toctree::
+
+    backend.api
+    backend.cases
+    backend.images
+    backend.static
+
+Module contents
+---------------
+
+.. automodule:: backend
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_interface/backend.static.rst
+++ b/docs/apidoc_interface/backend.static.rst
@@ -1,0 +1,38 @@
+backend\.static package
+=======================
+
+Submodules
+----------
+
+backend\.static\.apps module
+----------------------------
+
+.. automodule:: backend.static.apps
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+backend\.static\.tests module
+-----------------------------
+
+.. automodule:: backend.static.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+backend\.static\.urls module
+----------------------------
+
+.. automodule:: backend.static.urls
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: backend.static
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_interface/config.rst
+++ b/docs/apidoc_interface/config.rst
@@ -1,0 +1,37 @@
+config package
+==============
+
+Subpackages
+-----------
+
+.. toctree::
+
+    config.settings
+
+Submodules
+----------
+
+config\.urls module
+-------------------
+
+.. automodule:: config.urls
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+config\.wsgi module
+-------------------
+
+.. automodule:: config.wsgi
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: config
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_interface/config.settings.rst
+++ b/docs/apidoc_interface/config.settings.rst
@@ -1,0 +1,46 @@
+config\.settings package
+========================
+
+Submodules
+----------
+
+config\.settings\.base module
+-----------------------------
+
+.. automodule:: config.settings.base
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+config\.settings\.local module
+------------------------------
+
+.. automodule:: config.settings.local
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+config\.settings\.production module
+-----------------------------------
+
+.. automodule:: config.settings.production
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+config\.settings\.test module
+-----------------------------
+
+.. automodule:: config.settings.test
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: config.settings
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_interface/manage.rst
+++ b/docs/apidoc_interface/manage.rst
@@ -1,0 +1,7 @@
+manage module
+=============
+
+.. automodule:: manage
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_interface/modules.rst
+++ b/docs/apidoc_interface/modules.rst
@@ -1,0 +1,9 @@
+interface
+=========
+
+.. toctree::
+   :maxdepth: 4
+
+   backend
+   config
+   manage

--- a/docs/apidoc_prediction/config.rst
+++ b/docs/apidoc_prediction/config.rst
@@ -1,0 +1,7 @@
+config module
+=============
+
+.. automodule:: config
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_prediction/modules.rst
+++ b/docs/apidoc_prediction/modules.rst
@@ -1,0 +1,8 @@
+prediction
+==========
+
+.. toctree::
+   :maxdepth: 4
+
+   config
+   src

--- a/docs/apidoc_prediction/src.algorithms.classify.rst
+++ b/docs/apidoc_prediction/src.algorithms.classify.rst
@@ -1,0 +1,22 @@
+src\.algorithms\.classify package
+=================================
+
+Submodules
+----------
+
+src\.algorithms\.classify\.trained\_model module
+------------------------------------------------
+
+.. automodule:: src.algorithms.classify.trained_model
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: src.algorithms.classify
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_prediction/src.algorithms.identify.rst
+++ b/docs/apidoc_prediction/src.algorithms.identify.rst
@@ -1,0 +1,22 @@
+src\.algorithms\.identify package
+=================================
+
+Submodules
+----------
+
+src\.algorithms\.identify\.trained\_model module
+------------------------------------------------
+
+.. automodule:: src.algorithms.identify.trained_model
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: src.algorithms.identify
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_prediction/src.algorithms.rst
+++ b/docs/apidoc_prediction/src.algorithms.rst
@@ -1,0 +1,19 @@
+src\.algorithms package
+=======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    src.algorithms.classify
+    src.algorithms.identify
+    src.algorithms.segment
+
+Module contents
+---------------
+
+.. automodule:: src.algorithms
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_prediction/src.algorithms.segment.rst
+++ b/docs/apidoc_prediction/src.algorithms.segment.rst
@@ -1,0 +1,22 @@
+src\.algorithms\.segment package
+================================
+
+Submodules
+----------
+
+src\.algorithms\.segment\.trained\_model module
+-----------------------------------------------
+
+.. automodule:: src.algorithms.segment.trained_model
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: src.algorithms.segment
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_prediction/src.preprocess.rst
+++ b/docs/apidoc_prediction/src.preprocess.rst
@@ -1,0 +1,38 @@
+src\.preprocess package
+=======================
+
+Submodules
+----------
+
+src\.preprocess\.crop\_dicom module
+-----------------------------------
+
+.. automodule:: src.preprocess.crop_dicom
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+src\.preprocess\.errors module
+------------------------------
+
+.. automodule:: src.preprocess.errors
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+src\.preprocess\.load\_dicom module
+-----------------------------------
+
+.. automodule:: src.preprocess.load_dicom
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: src.preprocess
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_prediction/src.rst
+++ b/docs/apidoc_prediction/src.rst
@@ -1,0 +1,39 @@
+src package
+===========
+
+Subpackages
+-----------
+
+.. toctree::
+
+    src.algorithms
+    src.preprocess
+    src.tests
+
+Submodules
+----------
+
+src\.factory module
+-------------------
+
+.. automodule:: src.factory
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+src\.views module
+-----------------
+
+.. automodule:: src.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: src
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc_prediction/src.tests.rst
+++ b/docs/apidoc_prediction/src.tests.rst
@@ -1,0 +1,38 @@
+src\.tests package
+==================
+
+Submodules
+----------
+
+src\.tests\.test\_crop\_dicom module
+------------------------------------
+
+.. automodule:: src.tests.test_crop_dicom
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+src\.tests\.test\_endpoints module
+----------------------------------
+
+.. automodule:: src.tests.test_endpoints
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+src\.tests\.test\_load\_dicom module
+------------------------------------
+
+.. automodule:: src.tests.test_load_dicom
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: src.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,8 +33,8 @@ Welcome to Concept to Clinic's documentation!
    :maxdepth: 2
    :caption: Code Documentation
 
-   _apidoc_interface/modules
-   _apidoc_prediction/modules
+   apidoc_interface/modules
+   apidoc_prediction/modules
 
 
 


### PR DESCRIPTION
I added the auto-generated .rst files.

## Description
I removed `_apidoc_{prediction, interface}` from `.gitignore`, removed the underscore prefix and updated the references to the folders accordingly.

## Reference to official issue
This should fix #79 

## Motivation and Context
This should enable us to see the code documentation on http://concept-to-clinic.readthedocs.io/en/latest/ as well.

## How Has This Been Tested?
I ran  
`$ docs: make html && python -m http.server`
and saw the documentation on `localhost:8000`.
To test it on readthedocs as well, I created my own account and deployed the current master and this branch. With the [master](http://concept2clinic.readthedocs.io/en/master/) version you can see that there is no code documentation section. In the documentation for [this branch](http://concept2clinic.readthedocs.io/en/latest/), there is one.

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well