### PR TITLE
Added a note about Docker Toolbox for Windows 7 users

### DIFF
--- a/docs/developing-locally-docker.md
+++ b/docs/developing-locally-docker.md
@@ -16,7 +16,7 @@ The steps below will get you up and running with a local development environment
 You'll need a recent version of Docker. If you don't already have it installed, follow the instructions for your OS:
 
 - On Mac OS X, you'll need [`Docker for Mac`](https://docs.docker.com/engine/installation/mac/)
-- On Windows, you'll need [`Docker for Windows`](https://docs.docker.com/engine/installation/windows/)
+- On Windows, you'll need [`Docker for Windows`](https://docs.docker.com/engine/installation/windows/)  for 64bit Windows 10 Pro, Enterprise and Education or [`Docker Toolbox`](https://docs.docker.com/toolbox/overview/) for other versions
 - On Linux, you'll need [`docker-engine`](https://docs.docker.com/engine/installation/)
 
 Docker for Mac and Windows include Docker Compose, so most Mac and Windows users do not need to install it separately. For Linux users, follow the instructions for Linux installation in the [Docker documentation](https://docs.docker.com/compose/install/)


### PR DESCRIPTION
The Docker will not run on Windows 7 but the error is not informative and someone(like me) could spend lots of time trying to find what is the issue and how to solve it.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Windows 7 users should use **Docker Toolbox** instead of Docker. Docker installation will fail with not informative message _LightWeightInstaller has stopped working_. After enabling assembly binding logging (FusionLog) one may find, that the issue is `PresentationFramework.Aero2.dll` can't be found. But instead of trying to solve the issue, one should just use **Docker Toolbox**.



## CLA
- [ ] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well