### PR TITLE
#30 Add JSON case reports

### DIFF
--- a/interface/backend/api/serializers.py
+++ b/interface/backend/api/serializers.py
@@ -54,3 +54,10 @@ class NoduleSerializer(serializers.HyperlinkedModelSerializer):
         read_only_fields = ('created',)
 
     centroid = ImageLocationSerializer()
+
+    def create(self, validated_data):
+        return Nodule.objects.create(
+            case=validated_data['case'],
+            candidate=validated_data['candidate'],
+            centroid=ImageLocation.objects.create(**validated_data['centroid']),
+        )

--- a/interface/backend/api/urls.py
+++ b/interface/backend/api/urls.py
@@ -6,12 +6,14 @@ from backend.api.views import (
     ImageAvailableApiView,
     candidate_mark,
     candidate_dismiss,
+    case_report,
 )
 from django.conf.urls import (
     include,
     url
 )
 from rest_framework import routers
+from rest_framework.urlpatterns import format_suffix_patterns
 
 router = routers.DefaultRouter()
 router.register(r'cases', CaseViewSet)
@@ -26,3 +28,6 @@ urlpatterns = [
     url(r'^candidates/(?P<candidate_id>\d+)/dismiss$', candidate_dismiss, name='candidate-dismiss'),
     url(r'^candidates/(?P<candidate_id>\d+)/mark$', candidate_mark, name='candidate-mark'),
 ]
+
+# Support different suffixes
+urlpatterns += format_suffix_patterns([url(r'^cases/(?P<case_id>\d+)/report$', case_report, name='case-report')])

--- a/interface/backend/cases/models.py
+++ b/interface/backend/cases/models.py
@@ -1,9 +1,11 @@
+from backend.images.models import ImageSeriesSerializer, ImageLocationSerializer
 from django.core.validators import (
     MaxValueValidator,
     MinValueValidator
 )
 from django.db import models
 from django.utils import timezone
+from rest_framework import serializers
 
 
 class Case(models.Model):
@@ -39,3 +41,30 @@ class Nodule(models.Model):
     candidate = models.OneToOneField(Candidate, on_delete=models.CASCADE, null=True)
 
     centroid = models.OneToOneField('images.ImageLocation', on_delete=models.CASCADE)
+
+
+class CandidateSerializer(serializers.ModelSerializer):
+    centroid = ImageLocationSerializer(read_only=True)
+
+    class Meta:
+        model = Candidate
+        fields = ('id', 'created', 'centroid', 'case_id', 'probability_concerning')
+
+
+class NoduleSerializer(serializers.ModelSerializer):
+    candidates = CandidateSerializer(read_only=True, many=True)
+    centroid = ImageLocationSerializer(read_only=True)
+
+    class Meta:
+        model = Case
+        fields = ('id', 'created', 'candidates', 'centroid')
+
+
+class CaseSerializer(serializers.ModelSerializer):
+    series = ImageSeriesSerializer()
+    candidates = CandidateSerializer(read_only=True, many=True)
+    nodules = NoduleSerializer(read_only=True, many=True)
+
+    class Meta:
+        model = Case
+        fields = ('id', 'created', 'series', 'candidates', 'nodules')

--- a/interface/backend/cases/tests.py
+++ b/interface/backend/cases/tests.py
@@ -1,10 +1,14 @@
-from django.test import TestCase
+import json
 
 from backend.cases.factories import (
     CandidateFactory,
     CaseFactory,
     NoduleFactory
 )
+from backend.cases.models import Case, Candidate, Nodule
+from backend.images.models import ImageSeries, ImageLocation
+from django.test import TestCase
+from django.urls import reverse
 
 
 class SmokeTest(TestCase):
@@ -31,3 +35,66 @@ class SmokeTest(TestCase):
         self.assertIsInstance(nodule.centroid.x, int)
         self.assertIsInstance(nodule.centroid.y, int)
         self.assertIsInstance(nodule.centroid.z, int)
+
+    def test_report(self):
+        def assertDictContainsNestedSubset(superset, subset):
+            self.assertTrue(all(item in superset.items() for item in subset.items()))
+
+        url = reverse('case-report', kwargs={'case_id': 0}) + ".json"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+        series = ImageSeries.objects.create(patient_id='42', series_instance_uid='13', uri='/images/1.dcm')
+        case = Case.objects.create(series=series)
+        centroid1 = ImageLocation.objects.create(series=series, x=1, y=2, z=3)
+        candidate1 = Candidate.objects.create(case=case, centroid=centroid1, probability_concerning=0.8)
+        centroid2 = ImageLocation.objects.create(series=series, x=10, y=20, z=30)
+        candidate2 = Candidate.objects.create(case=case, centroid=centroid2, probability_concerning=0.98)
+        nodule1 = Nodule.objects.create(case=case, candidate=candidate1, centroid=centroid1)
+        nodule2 = Nodule.objects.create(case=case, candidate=candidate2, centroid=centroid2)
+
+        url = reverse('case-report', kwargs={'case_id': case.id}) + ".json"
+        response = self.client.get(url)
+        payload = json.loads(response.content)
+        self.assertEqual(payload['id'], case.id)
+
+        self.assertDictContainsSubset(payload['series'],
+                                      {'id': series.id, 'patient_id': '42', 'series_instance_uid': '13',
+                                       'uri': '/images/1.dcm'})
+
+        candidate1_dict = payload['candidates'][0]
+        self.assertEqual(candidate1_dict['id'], candidate1.id)
+        self.assertEqual(candidate1_dict['case_id'], case.id)
+        self.assertEqual(candidate1_dict['probability_concerning'], 0.8)
+        self.assertEqual(candidate1_dict['centroid']['series'],
+                         {'id': series.id, 'patient_id': '42', 'series_instance_uid': '13', 'uri': '/images/1.dcm'})
+        self.assertEqual(candidate1_dict['centroid']['x'], 1)
+        self.assertEqual(candidate1_dict['centroid']['y'], 2)
+        self.assertEqual(candidate1_dict['centroid']['z'], 3)
+
+        candidate2_dict = payload['candidates'][1]
+        self.assertEqual(candidate2_dict['id'], candidate2.id)
+        self.assertEqual(candidate2_dict['case_id'], case.id)
+        self.assertEqual(candidate2_dict['probability_concerning'], 0.98)
+        self.assertEqual(candidate2_dict['centroid']['series'],
+                         {'id': series.id, 'patient_id': '42', 'series_instance_uid': '13', 'uri': '/images/1.dcm'})
+        self.assertEqual(candidate2_dict['centroid']['x'], 10)
+        self.assertEqual(candidate2_dict['centroid']['y'], 20)
+        self.assertEqual(candidate2_dict['centroid']['z'], 30)
+
+        nodule1_dict = payload['nodules'][0]
+        self.assertEqual(nodule1_dict['id'], nodule1.id)
+        self.assertEqual(nodule1_dict['centroid']['id'], centroid1.id)
+        self.assertEqual(nodule1_dict['centroid']['series'],
+                         {'id': series.id, 'patient_id': '42', 'series_instance_uid': '13', 'uri': '/images/1.dcm'})
+        self.assertEqual(nodule1_dict['centroid']['x'], 1)
+        self.assertEqual(nodule1_dict['centroid']['y'], 2)
+        self.assertEqual(nodule1_dict['centroid']['z'], 3)
+
+        nodule2_dict = payload['nodules'][1]
+        self.assertEqual(nodule2_dict['id'], nodule2.id)
+        self.assertEqual(nodule2_dict['centroid']['series'],
+                         {'id': series.id, 'patient_id': '42', 'series_instance_uid': '13', 'uri': '/images/1.dcm'})
+        self.assertEqual(nodule2_dict['centroid']['x'], 10)
+        self.assertEqual(nodule2_dict['centroid']['y'], 20)
+        self.assertEqual(nodule2_dict['centroid']['z'], 30)

--- a/interface/backend/images/models.py
+++ b/interface/backend/images/models.py
@@ -1,7 +1,9 @@
+import glob
+
+import dicom
 from django.db import models
 from django.utils._os import safe_join
-import dicom
-import glob
+from rest_framework import serializers
 
 
 class ImageSeries(models.Model):
@@ -36,6 +38,12 @@ class ImageSeries(models.Model):
             uri=uri)
 
 
+class ImageSeriesSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ImageSeries
+        fields = ('id', 'patient_id', 'series_instance_uid', 'uri')
+
+
 class ImageLocation(models.Model):
     """
     Model representing a certain voxel location on certain image
@@ -47,3 +55,11 @@ class ImageLocation(models.Model):
     y = models.PositiveSmallIntegerField(help_text='Voxel index for Y axis, zero-index, from top left')
 
     z = models.PositiveSmallIntegerField(help_text='Slice index for Z axis, zero-index')
+
+
+class ImageLocationSerializer(serializers.ModelSerializer):
+    series = ImageSeriesSerializer()
+
+    class Meta:
+        model = ImageLocation
+        fields = ('id', 'series', 'x', 'y', 'z')


### PR DESCRIPTION
This PR is based on and blocked by #93 (because this already adds a proper creation of candidates). To see the raw changes this PR wants to add, please see [here](https://github.com/WGierke/concept-to-clinic/compare/36_accept_reject_candidates...WGierke:30_case_json_report).
Now, a JSON report can be generated for a case that includes the patient id, candidates, nodules, etc.

## Description
I fixed the creation of nodules, added the JSON report and wrote a test for that.

## Reference to official issue
This addresses #30.

## Motivation and Context
This should summarize the data of a case and help debugging.

## How Has This Been Tested?
I wrote a test which adds a case with image series, candidates and nodules and which tests for a proper report.

## Screenshots (if appropriate):
![screenshot from 2017-09-06 15-43-02](https://user-images.githubusercontent.com/6676439/30115903-5b97ae02-931c-11e7-82ca-f5d92d41a175.png)

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well