### PR TITLE
#31 Directory List of Datasource

### DIFF
--- a/interface/backend/api/tests.py
+++ b/interface/backend/api/tests.py
@@ -3,6 +3,8 @@ from django.test import (
     TestCase
 )
 from django.urls import reverse
+from rest_framework.test import APIRequestFactory
+from rest_framework import status
 
 from backend.api.serializers import NoduleSerializer
 from backend.cases.factories import (
@@ -14,6 +16,7 @@ from backend.cases.factories import (
 class ViewTest(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
+        self.rest_factory = APIRequestFactory()
 
     def test_nodule_list_viewset(self):
         # first try an endpoint without a nodule
@@ -33,3 +36,8 @@ class ViewTest(TestCase):
         response = self.client.get(url)
         payload = response.json()
         self.assertListEqual(payload, expected)
+
+    def test_images_available_view(self):
+        url = reverse('images-available')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/interface/backend/api/views.py
+++ b/interface/backend/api/views.py
@@ -1,4 +1,5 @@
 import os
+from django.conf import settings
 from backend.api import serializers
 from backend.cases.models import (
     Case,
@@ -52,22 +53,17 @@ class ImageAvailableApiView(APIView):
         
         TODO Dynamically fetch deeper directories
         """
-        # example source:
-        # /images/LIDC-IDRI-0001/1.3.6.1.4.1.14519.5.2.1.6279.6001.298806137288633453246975630178
-        src_dir = os.environ.get('IMAGE_SOURCE', '/images')
+        src_dir = settings.DATASOURCE_DIR
         fss = FileSystemStorage(src_dir)
         list_dirs = fss.listdir(src_dir)
-        dirs = sorted(list_dirs[0])
         tree = []
-        if dirs:
-            for dirname in dirs:
-                dir_contents = fss.listdir(os.path.join(src_dir, dirname))
-                filenames = sorted(dir_contents[1])
-                dir_node = {
-                    'name': dirname,
-                    'children': filenames
-                }   
-                tree.append(dir_node)
+        for dirname in sorted(list_dirs[0]):
+            dir_contents = fss.listdir(os.path.join(src_dir, dirname))
+            dir_node = {
+                'name': dirname,
+                'children': sorted(dir_contents[1]),
+            }   
+            tree.append(dir_node)
         return JsonResponse({'directories': tree})
 
 

--- a/interface/backend/api/views.py
+++ b/interface/backend/api/views.py
@@ -5,6 +5,7 @@ from backend.cases.models import (
     Nodule,
 )
 from rest_framework.views import APIView
+from rest_framework.response import Response
 from backend.images.models import ImageSeries
 from django.http import JsonResponse
 from rest_framework import viewsets

--- a/interface/backend/api/views.py
+++ b/interface/backend/api/views.py
@@ -4,7 +4,7 @@ from backend.cases.models import (
     Candidate,
     Nodule,
 )
-from rest_framework.views import APIView 
+from rest_framework.views import APIView
 from backend.images.models import ImageSeries
 from django.http import JsonResponse
 from rest_framework import viewsets

--- a/interface/backend/api/views.py
+++ b/interface/backend/api/views.py
@@ -42,15 +42,14 @@ class ImageAvailableApiView(APIView):
 
     def get(self, request):
         """
-        Return a sorted(by name) list of files and folders 
+        Return a sorted(by name) list of files and folders
         in dataset in the form
         {'directories': [
             {
                 'name': directory_name1,
                 'children': [ file_name1, file_name2, ... ]
             }, ... ]
-        }
-        
+        }        
         TODO Dynamically fetch deeper directories
         """
         src_dir = settings.DATASOURCE_DIR
@@ -62,7 +61,7 @@ class ImageAvailableApiView(APIView):
             dir_node = {
                 'name': dirname,
                 'children': sorted(dir_contents[1]),
-            }   
+            }
             tree.append(dir_node)
         return JsonResponse({'directories': tree})
 

--- a/interface/backend/api/views.py
+++ b/interface/backend/api/views.py
@@ -4,6 +4,7 @@ from backend.cases.models import (
     Candidate,
     Nodule,
 )
+from rest_framework.views import APIView 
 from backend.images.models import ImageSeries
 from django.http import JsonResponse
 from rest_framework import viewsets

--- a/interface/backend/api/views.py
+++ b/interface/backend/api/views.py
@@ -11,7 +11,6 @@ from rest_framework.response import Response
 from backend.images.models import ImageSeries
 from django.http import JsonResponse
 from rest_framework import viewsets
-from rest_framework.views import APIView
 from django.core.files.storage import FileSystemStorage
 
 

--- a/interface/config/settings/base.py
+++ b/interface/config/settings/base.py
@@ -15,7 +15,8 @@ BASE_DIR = environ.Path(__file__) - 3
 APPS_DIR = BASE_DIR.path('backend')
 
 # Datasource from where the images will be loaded initially
-DATASOURCE_DIR = "/images/LIDC-IDRI-0001/1.3.6.1.4.1.14519.5.2.1.6279.6001.298806137288633453246975630178"
+DATASOURCE_DIR = '/images/LIDC-IDRI-0001/' \
+                '1.3.6.1.4.1.14519.5.2.1.6279.6001.298806137288633453246975630178'
 
 env = environ.Env()
 env.read_env(str(BASE_DIR.path('.env')))

--- a/interface/config/settings/base.py
+++ b/interface/config/settings/base.py
@@ -15,8 +15,7 @@ BASE_DIR = environ.Path(__file__) - 3
 APPS_DIR = BASE_DIR.path('backend')
 
 # Datasource from where the images will be loaded initially
-DATASOURCE_DIR = '/images/LIDC-IDRI-0001/' \
-                '1.3.6.1.4.1.14519.5.2.1.6279.6001.298806137288633453246975630178'
+DATASOURCE_DIR = '/images'
 
 env = environ.Env()
 env.read_env(str(BASE_DIR.path('.env')))

--- a/interface/config/settings/base.py
+++ b/interface/config/settings/base.py
@@ -14,6 +14,9 @@ import environ
 BASE_DIR = environ.Path(__file__) - 3
 APPS_DIR = BASE_DIR.path('backend')
 
+# Datasource from where the images will be loaded initially
+DATASOURCE_DIR = "/images/LIDC-IDRI-0001/1.3.6.1.4.1.14519.5.2.1.6279.6001.298806137288633453246975630178"
+
 env = environ.Env()
 env.read_env(str(BASE_DIR.path('.env')))
 


### PR DESCRIPTION
Return simple 2 level directory listing from `/images/available` api

## Description
`/images/available` will return directory and files in alphanumerically sequential order

## Reference to official issue
issue #31 

## Motivation and Context
Current API return only emplty list.


## How Has This Been Tested?
Unit test added to test http response. We have tested against the test image direcotry available at `/images/LIDC-IDRI-0001/1.3.6.1.4.1.14519.5.2.1.6279.6001.298806137288633453246975630178` which return following direcotry list in alphabetical order

## Screenshots (if appropriate):
In Index Page:
![concept to clinic](https://user-images.githubusercontent.com/2689863/30239141-dfde2eae-9577-11e7-9c30-1ddc0f94a865.png)

API returns:
![image available api django rest framework](https://user-images.githubusercontent.com/2689863/30239143-e558d4ba-9577-11e7-8ef7-99958e3a6fce.png)

## Updates of Acceptance Criteria
- [x] Correct hierarchical listing
- [x] Sorted alphabetically

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well