### PR TITLE
#111 Replace JsonResponses by Responses

### DIFF
--- a/docs/apidoc_interface/backend.rst
+++ b/docs/apidoc_interface/backend.rst
@@ -9,7 +9,6 @@ Subpackages
     backend.api
     backend.cases
     backend.images
-    backend.static
 
 Module contents
 ---------------

--- a/interface/backend/api/tests.py
+++ b/interface/backend/api/tests.py
@@ -1,16 +1,16 @@
+from backend.api.serializers import NoduleSerializer
+from backend.cases.factories import (
+    CaseFactory,
+    CandidateFactory,
+    NoduleFactory
+)
 from django.test import (
     RequestFactory,
     TestCase
 )
 from django.urls import reverse
-from rest_framework.test import APIRequestFactory
 from rest_framework import status
-
-from backend.api.serializers import NoduleSerializer
-from backend.cases.factories import (
-    CaseFactory,
-    NoduleFactory
-)
+from rest_framework.test import APIRequestFactory
 
 
 class ViewTest(TestCase):
@@ -40,4 +40,20 @@ class ViewTest(TestCase):
     def test_images_available_view(self):
         url = reverse('images-available')
         response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_candidates_mark(self):
+        candidate = CandidateFactory()
+        url = reverse('candidate-mark', kwargs={'candidate_id': candidate.id})
+        response = self.client.get(url)
+        response_dict = response.json()
+        self.assertEqual(response_dict["response"], "Candidate {} was marked".format(candidate.id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_candidates_dismiss(self):
+        candidate = CandidateFactory()
+        url = reverse('candidate-dismiss', kwargs={'candidate_id': candidate.id})
+        response = self.client.get(url)
+        response_dict = response.json()
+        self.assertEqual(response_dict["response"], "Candidate {} was dismissed".format(candidate.id))
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/interface/backend/api/views.py
+++ b/interface/backend/api/views.py
@@ -1,17 +1,18 @@
 import os
-from django.conf import settings
+
 from backend.api import serializers
 from backend.cases.models import (
     Case,
     Candidate,
     Nodule,
 )
-from rest_framework.views import APIView
-from rest_framework.response import Response
 from backend.images.models import ImageSeries
-from django.http import JsonResponse
-from rest_framework import viewsets
+from django.conf import settings
 from django.core.files.storage import FileSystemStorage
+from rest_framework import viewsets
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 
 class CaseViewSet(viewsets.ModelViewSet):
@@ -80,12 +81,14 @@ class ImageAvailableApiView(APIView):
         }
         """
         tree = self.walk(settings.DATASOURCE_DIR)
-        return JsonResponse({'directories': tree})
+        return Response({'directories': tree})
 
 
+@api_view(['GET'])
 def candidate_mark(request, candidate_id):
-    return JsonResponse({'response': "Candidate {} was marked".format(candidate_id)})
+    return Response({'response': "Candidate {} was marked".format(candidate_id)})
 
 
+@api_view(['GET'])
 def candidate_dismiss(request, candidate_id):
-    return JsonResponse({'response': "Candidate {} was dismissed".format(candidate_id)})
+    return Response({'response': "Candidate {} was dismissed".format(candidate_id)})


### PR DESCRIPTION
I replaced JsonResponses by Responses which follows the DRF idioms.

## Reference to official issue
This addresses #111 .

## How Has This Been Tested?
I added two tests so all functions, that previously used JsonResonses, are tested whether they still return valid JSON.

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well