### PR TITLE
#127: Fix typo in issue template: local.py -> local.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -28,7 +28,7 @@
 <!--- Not obligatory, but suggest an idea for implementing addition or change -->
 
 ## Checklist before submitting
-- [ ] I have confirmed this using the officially supported Docker Compose setup using the `local.py` configuration and ensured that I built the containers again and they reflect the most recent version of the project at the `HEAD` commit on the `master` branch 
+- [ ] I have confirmed this using the officially supported Docker Compose setup using the `local.yml` configuration and ensured that I built the containers again and they reflect the most recent version of the project at the `HEAD` commit on the `master` branch 
 - [ ] I have searched through the other currently open issues and am confident this is not a duplicate of an existing bug
 - [ ] I provided a **minimal code snippet** or list of steps that reproduces the bug.
 - [ ] I provided **screenshots** where appropriate


### PR DESCRIPTION
I replaced `local.py` with `local.yml` in the issue template. This addresses #127 .

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well