### PR TITLE
Fix documentation compilation

### DIFF
--- a/compose/documentation/Dockerfile-dev
+++ b/compose/documentation/Dockerfile-dev
@@ -1,0 +1,15 @@
+FROM python:3.6
+ENV PYTHONUNBUFFERED 1
+
+# Requirements have to be pulled and installed here, otherwise caching won't work
+COPY ./prediction/requirements /requirements/prediction
+RUN pip install -r /requirements/prediction/local.txt
+
+COPY ./interface/requirements /requirements/interface
+RUN pip install -r /requirements/interface/local.txt
+
+# Documentation
+COPY ./docs/requirements.txt /requirements/requirements.txt
+RUN pip install -r /requirements/requirements.txt
+
+WORKDIR /app

--- a/docs/apidoc_interface/backend.static.rst
+++ b/docs/apidoc_interface/backend.static.rst
@@ -4,39 +4,6 @@ backend.static package
 Submodules
 ----------
 
-backend.static.apps module
---------------------------
-
-.. automodule:: backend.static.apps
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-backend.static.context_processors module
-----------------------------------------
-
-.. automodule:: backend.static.context_processors
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-backend.static.tests module
----------------------------
-
-.. automodule:: backend.static.tests
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-backend.static.urls module
---------------------------
-
-.. automodule:: backend.static.urls
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
 Module contents
 ---------------
 

--- a/docs/apidoc_prediction/src.tests.rst
+++ b/docs/apidoc_prediction/src.tests.rst
@@ -4,6 +4,14 @@ src.tests package
 Submodules
 ----------
 
+src.tests.test_calculate_volume module
+--------------------------------------
+
+.. automodule:: src.tests.test_calculate_volume
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 src.tests.test_classify_trained_model_predict module
 ----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,12 +19,15 @@
 #
 import os
 import sys
+import django
 
 DOCS_DIR = os.getcwd()
 PROJECT_DIR = os.path.abspath(os.path.join(DOCS_DIR, os.pardir))
 
 INTERFACE_DIR = os.path.join(PROJECT_DIR, 'interface')
 sys.path.insert(0, INTERFACE_DIR)
+
+django.setup()  # Needed to document interface app with sphinx
 
 PREDICTION_DIR = os.path.join(PROJECT_DIR, 'prediction')
 sys.path.insert(0, PREDICTION_DIR)

--- a/interface/backend/api/views.py
+++ b/interface/backend/api/views.py
@@ -71,7 +71,7 @@ class ImageAvailableApiView(APIView):
         in dataset
 
         Format::
-        
+
             {'directories': [
                 {
                     'name': directory_name1,

--- a/interface/backend/api/views.py
+++ b/interface/backend/api/views.py
@@ -68,24 +68,27 @@ class ImageAvailableApiView(APIView):
     def get(self, request):
         """
         Return a sorted(by name) list of files and folders
-        in dataset in the form
-        {'directories': [
-            {
-                'name': directory_name1,
-                'children': [
-                    file_name1,
-                    file_name2,
-                    {
-                        'name': 'nested_dir_1',
-                        'children': [
-                            'file_name_1',
-                            'file_name_2',
-                            ....
-                        ]
-                    }
-                    ... ]
-            }, ... ]
-        }
+        in dataset
+
+        Format::
+        
+            {'directories': [
+                {
+                    'name': directory_name1,
+                    'children': [
+                        file_name1,
+                        file_name2,
+                        {
+                            'name': 'nested_dir_1',
+                            'children': [
+                                'file_name_1',
+                                'file_name_2',
+                                ....
+                            ]
+                        }
+                        ... ]
+                }, ... ]
+            }
         """
         tree = self.walk(settings.DATASOURCE_DIR)
         return Response({'directories': tree})

--- a/local.yml
+++ b/local.yml
@@ -67,3 +67,34 @@ services:
       - ./prediction/src/algorithms/classify/assets/:/classify_models
     ports:
       - "8001:8001"
+
+  compile_docs:
+      restart: always
+      depends_on:
+        - postgres
+      environment:
+        - POSTGRES_USER=concepttoclinic
+        - USE_DOCKER=yes
+        - SECRET_KEY=notverysecret
+        - DEBUG=True
+        - DJANGO_SETTINGS_MODULE=config.settings.local
+      build:
+        context: .
+        dockerfile: ./compose/documentation/Dockerfile-dev
+      volumes:
+        - ./:/app
+      command: bash -c "source compose/interface/entrypoint.sh && make -C /app/docs html"
+
+  documentation:
+    build:
+      context: .
+      dockerfile: ./compose/documentation/Dockerfile-dev
+    depends_on:
+      - compile_docs
+    working_dir: /app/docs/_build/html
+    volumes:
+      - ./docs/_build/html:/app/docs/_build/html
+      - ./:/app
+    command: python -m http.server
+    ports:
+      - "8002:8000"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Turned out to be pretty finicky to fix, Sphinx (apidoc) and Django can be a pain to get working together. Changes made:
 - Re-add the two Docker images (`compile_docs` and `documentation`). I've setup a new Docker file for both of these images that uses the requirements from the interface and prediction modules as well as the documentation-specific requirement file.
 - Add some required additional environment variables to allow Django to at least be importable for Sphinx's apidoc. I re-use the `compose/interface/entrypoint.sh` file from the `interface` module to setup the `DATABASE_URL` env variable that's required for django, before running the Sphinx makefile. Currently a blank string works for the URL, but I'm future-proofing in case a real URL becomes necessary for Sphinx in the future.
 - Fix some minor formatting issues in the docstrings which were throwing some warnings
 - Remove the references to `backend.static` but leave the module in as the folder still appears to be in the `master` branch.

## Reference to official issue
<!--- If fixing a bug, there should be an existing issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #90.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If adding a new feature or making improvements not already reflected in an official issue, please reference the relevant sections of the design doc -->
Fix documentation compilation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've run the compilation commands in the original issue and also run the whole Docker stack. It seems to compile and serve the documentation at `http://localhost:8002` without issue. Some Sphinx warnings remain regarding unreferenced MD files that I'm assuming will be used later.

## Screenshots (if appropriate):


## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well