### PR TITLE
Implemented simple nodule segmentation algorithm

### DIFF
--- a/prediction/src/algorithms/segment/src/levelset_segment.py
+++ b/prediction/src/algorithms/segment/src/levelset_segment.py
@@ -1,0 +1,63 @@
+import SimpleITK as sitk
+
+
+def segment_nodule(image: sitk.Image, nodule: dict, lower_threshold=-600, upper_threshold=500, maximum_rms_error=0.02,
+                   number_of_iterations=1000, curvature_scaling=0.5, radius=3):
+    """
+    Given an image and a nodule location, this function segments the nodule, using the
+    ThresholdSegmentationLevelSetImageFilter from ITK.
+    See https://itk.org/Doxygen/html/classitk_1_1SegmentationLevelSetImageFilter.html for further details on the Method
+
+    Args:
+      image: sitk.Image: Input Image
+      nodule: dict: Nodule coordinates, in the form {"x": 1, "y": 1, "z": 1}
+      lower_threshold:  Lower Hu threshold of the nodule to be segmented. Should be about the Hu of lung
+                      (Default value = -600)
+      upper_threshold: Upper Hu threshold of the nodule to be segmented. Should be less than the Hu of bone
+                       (Default value = 500)
+      maximum_rms_error: Stopping condition for the iterative solver.
+      number_of_iterations: Maximum number of iterations to run
+      curvature_scaling: Controls the smoothness of the contour. Higher value - smoother contour
+      radius: Sets the radius of the initial segmentation around the nodule.
+
+    Returns:
+        mask: filepath to segmentation mask
+        diameters: list of diameters
+        volumes: list of  volumes
+
+    """
+
+    seed = (nodule["x"], nodule["y"], nodule["z"])
+    # Create initial levelset based on the seed and the signed Maurer distance
+    seg = sitk.Image(image.GetSize(), sitk.sitkUInt8)
+    seg.CopyInformation(image)
+    seg[seed] = 1
+    # Binary dilate enlarges the seed mask by 3 pixels in all directions.
+    seg = sitk.BinaryDilate(seg, radius)
+    init_ls = sitk.SignedMaurerDistanceMap(seg, insideIsPositive=True, useImageSpacing=True)
+
+    lsFilter = sitk.ThresholdSegmentationLevelSetImageFilter()
+    # Sets the Hu value range for the nodule
+    lsFilter.SetLowerThreshold(lower_threshold)
+    lsFilter.SetUpperThreshold(upper_threshold)
+    # Set stopping conditions
+    lsFilter.SetMaximumRMSError(maximum_rms_error)
+    lsFilter.SetNumberOfIterations(number_of_iterations)
+    # CurvatureScaling controls how smooth the contour will be.
+    lsFilter.SetCurvatureScaling(curvature_scaling)
+    # PropagationScaling is also known as "balloon-force". Causes the segmented area to grow.
+    lsFilter.SetPropagationScaling(1)
+    lsFilter.ReverseExpansionDirectionOn()
+    ls = lsFilter.Execute(init_ls, sitk.Cast(image, sitk.sitkFloat32))
+    # Convert to binary mask
+    mask = ls > 0
+
+    # Calculate diameter and volume
+    stats = sitk.LabelShapeStatisticsImageFilter()
+    stats.ComputeFeretDiameterOn()
+    stats.SetBackgroundValue(0)
+    stats.Execute(mask)
+    diameter = stats.GetFeretDiameter(1)
+    volume = stats.GetPhysicalSize(1)
+
+    return mask, diameter, volume

--- a/prediction/src/tests/test_segment_nodules.py
+++ b/prediction/src/tests/test_segment_nodules.py
@@ -1,0 +1,27 @@
+import pytest
+import numpy as np
+from scipy.ndimage.measurements import label
+from ..algorithms.segment import trained_model
+
+
+@pytest.fixture
+def dicom_path():
+    yield '../images/LIDC-IDRI-0001/1.3.6.1.4.1.14519.5.2.1.6279.6001.298806137288633453246975630178/' \
+          '1.3.6.1.4.1.14519.5.2.1.6279.6001.179049373636438705059720603192'
+
+
+@pytest.fixture
+def nodule_locations():
+    yield [{"x": 187, "y": 217, "z": 7}, {"x": 317, "y": 367, "z": 7}]
+
+
+def test_nodule_segmentation(dicom_path, nodule_locations):
+    predictions = trained_model.predict(dicom_path, nodule_locations)
+
+    mask = np.load(predictions["binary_mask_path"])
+
+    assert np.sum(mask) > 0
+    _, num_features = label(mask)
+    assert num_features == 2
+    assert len(predictions["volumes"]) == 2
+    assert len(predictions["diameters"]) == 2

--- a/prediction/src/utils.py
+++ b/prediction/src/utils.py
@@ -1,0 +1,18 @@
+import tempfile
+_FILES = []
+
+
+def get_temporary_file(suffix=None):
+    """
+    Creates a temporary file, and ensures that it is removed when the programs exits, but not before
+    Args:
+        suffix: Extension of the file to be created. Must include the dot if required
+
+    Returns:
+        A temporary file object
+
+    """
+
+    temporary_file = tempfile.NamedTemporaryFile(suffix=suffix)
+    _FILES.append(temporary_file)
+    return temporary_file


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request implements a simple level-set based segmentation algorithm for nodule segmentation.

## Description
<!--- Describe your changes in detail -->
This implements a simple segmentation algorithm based on SITK, and returns binary mask, diameter and volume.

## Reference to official issue
<!--- If fixing a bug, there should be an existing issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If adding a new feature or making improvements not already reflected in an official issue, please reference the relevant sections of the design doc -->
Part of minimal viable product.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The segmentation has been tested manually on a few LIDC images. A better approach would be a test based on pylidc and report dice values.

## Screenshots (if appropriate):
![Nodule Segmentation](https://i.imgur.com/QBwqU2D.png)

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well