### PR TITLE
#143 Segmentation Evaluation

### DIFF
--- a/prediction/src/algorithms/segment/src/evaluate.py
+++ b/prediction/src/algorithms/segment/src/evaluate.py
@@ -1,0 +1,115 @@
+import numpy as np
+import scipy.spatial
+
+
+def hausdorff_distance(ground_true, predicted):
+    """Computes the Hausdorff distance, uses `scipy` implementation of 'an efficient algorithm for
+    calculating the exact Hausdorff distance.' provided by A. A. Taha et al.
+
+    Args:
+        ground_true ground_true (np.ndarray[bool]): ground true mask to be compared with predicted one.
+        predicted predicted (np.ndarray[bool]): predicted mask, allowed values are from {True, False}.
+            Should be the same dimension as `ground_true`.
+    Returns:
+        double: The directed Hausdorff distance.
+    """
+    u = np.array(np.where(ground_true)).T
+    v = np.array(np.where(predicted)).T
+    hd, _, _ = scipy.spatial.distance.directed_hausdorff(u, v)
+    return hd
+
+
+def sensitivity(ground_true, predicted):
+    """Computes the sensitivity.
+
+    Args:
+        ground_true ground_true (np.ndarray[bool]): ground true mask to be compared with predicted one.
+        predicted predicted (np.ndarray[bool]): predicted mask.
+            Should be the same dimension as `ground_true`.
+    Returns:
+        double: The sensitivity.
+    """
+    P = np.sum(ground_true)
+    TP = np.sum(ground_true * predicted)
+    return P / TP
+
+
+def specificity(ground_true, predicted):
+    """Computes the specificity.
+
+    Args:
+        ground_true ground_true (np.ndarray[bool]): ground true mask to be compared with predicted one.
+        predicted predicted (np.ndarray[bool]): predicted mask.
+            Should be the same dimension as `ground_true`.
+    Returns:
+        double: The specificity.
+    """
+    N = np.prod(ground_true.shape) - np.sum(ground_true)
+    TN = np.sum(np.logical_not(ground_true) * np.logical_not(predicted))
+    return N / TN
+
+
+def dice_coefficient(ground_true, predicted):
+    """Computes the Dice dissimilarity coefficient via `scipy` implementation.
+
+    Args:
+        ground_true ground_true (np.ndarray[bool]): 1-dimensional raveled ground true mask
+            to be compared with predicted one.
+        predicted predicted (np.ndarray[bool]): 1-dimensional raveled predicted mask.
+    Returns:
+        double: The Dice dissimilarity.
+    """
+
+    return scipy.spatial.distance.dice(ground_true, predicted)
+
+
+def dice_coefficient_uns(ground_true, predicted, smooth=1e-1):
+    """The analogy of Dice coefficient provided by one of participants of ultrasound
+    nerve segmentation Kaggle challenge. The implementation was adopted from:
+    https://github.com/jocicmarko/ultrasound-nerve-segmentation/blob/master/train.py
+
+    Args:
+        ground_true ground_true (np.ndarray[bool]): ground true mask to be compared with predicted one.
+        predicted predicted (np.ndarray[bool | float]): predicted mask, the values lies either in [0, 1] or
+            in {True, False}. Should be the same dimension as `ground_true`.
+        smooth (float): differs of the default value from the original implementation, was
+            caused by the difference of ordinary mask volume.
+    Returns:
+        double: The analogy of Dice coefficient
+    """
+
+    intersection = 2. * np.sum(ground_true * predicted) + smooth
+    union = np.sum(ground_true) + np.sum(predicted) + smooth
+
+    return np.mean(intersection / union)
+
+
+def evaluate(ground_true, predicted, threshold=0., uns_smooth=1e-1):
+    """The function to orchestrate the evaluations.
+
+    Args:
+        ground_true (np.ndarray[bool]): ground true mask to be compared with predicted one.
+        predicted (np.ndarray[bool | float]): predicted mask, the values lies either in [0, 1] or in {True, False}
+            Should be the same dimension as `ground_true`.
+        threshold (float): if the `predicted.dtype` is not boolean, then `predicted` = `predicted` > `threshold`.
+            The default value is 0.
+        uns_smooth (float): used by a Dice coefficient analogy provided by one of participants of
+            ultrasound nerve segmentation Kaggle challenge.
+    Returns:
+        dictionary contained magnitudes of the metrics of type ::
+            {hausdorff_distance (double)
+             dice_coefficient_uns (double)
+             sensitivity (double)
+             specificity (double)
+             dice_coefficient (double)}.
+    """
+    metrics = dict()
+    metrics['hausdorff_distance'] = hausdorff_distance(ground_true, predicted)
+    metrics['dice_coefficient_uns'] = dice_coefficient_uns(ground_true, predicted, uns_smooth)
+
+    ground_true_f = np.ravel(ground_true) > threshold
+    predicted_f = np.ravel(predicted) > threshold
+    metrics['sensitivity'] = sensitivity(ground_true_f, predicted_f)
+    metrics['specificity'] = specificity(ground_true_f, predicted_f)
+    metrics['dice_coefficient'] = dice_coefficient(ground_true_f, predicted_f)
+    return metrics

--- a/prediction/src/tests/test_segment_evaluate.py
+++ b/prediction/src/tests/test_segment_evaluate.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pytest
+
+from ..algorithms.segment.src import evaluate
+
+
+@pytest.fixture(scope='session')
+def masks():
+    ones = np.ones((10, 10, 10))
+    zeros = np.zeros((10, 10, 10))
+    combined = np.concatenate([zeros, ones], axis=0)
+    combined_1 = np.concatenate([combined, combined], axis=1)
+    combined_2 = np.concatenate([np.swapaxes(combined, 0, 1),
+                                 np.swapaxes(combined, 0, 1)], axis=0)
+    yield combined_1, combined_2
+
+
+def test_segment_evaluate_hausdorff_distance(masks):
+    combined_1, combined_2 = masks
+    assert np.abs(10. - evaluate.hausdorff_distance(combined_1, combined_2)) < 1e-4
+
+
+def test_segment_evaluate_dice_coefficient_uns(masks):
+    combined_1, combined_2 = masks
+    assert np.abs(.5 - evaluate.dice_coefficient_uns(combined_1, combined_2, smooth=1e-1)) < 1e-4
+
+
+def test_segment_evaluate_dice_coefficient(masks):
+    combined_1, combined_2 = masks
+    combined_1 = np.ravel(combined_1).astype(np.bool_)
+    combined_2 = np.ravel(combined_2).astype(np.bool_)
+    assert .5 == evaluate.dice_coefficient(combined_1, combined_2)
+
+
+def test_segment_evaluate_sensitivity(masks):
+    combined_1, combined_2 = masks
+    combined_1 = np.ravel(combined_1).astype(np.bool_)
+    combined_2 = np.ravel(combined_2).astype(np.bool_)
+    assert 2. == evaluate.sensitivity(combined_1, combined_2)
+
+
+def test_segment_evaluate_specificity(masks):
+    combined_1, combined_2 = masks
+    combined_1 = np.ravel(combined_1).astype(np.bool_)
+    combined_2 = np.ravel(combined_2).astype(np.bool_)
+    assert 2. == evaluate.specificity(combined_1, combined_2)
+
+
+def test_segment_evaluate_evaluate(masks):
+    combined_1, combined_2 = masks
+    desired_behaviour = {'hausdorff_distance': 10.0,
+                         'dice_coefficient_uns': 0.5,
+                         'sensitivity': 2.0,
+                         'specificity': 2.0,
+                         'dice_coefficient': 0.5}
+    calculated = evaluate.evaluate(combined_1, combined_2)
+    for key, output in desired_behaviour.items():
+        assert np.abs(output - calculated[key]) < 1e-4, 'The output of function %s is %f, while %f was expected.' % \
+                                                        (key, calculated, output)


### PR DESCRIPTION
The followed measures and distances have been provided: sensitivity, specificity, [Dice coefficient](https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient), the [analogy to Dice coefficient](https://github.com/jocicmarko/ultrasound-nerve-segmentation/blob/master/train.py) and [Hausdorff distance](https://en.wikipedia.org/wiki/Hausdorff_distance). This metrics may be employed for segmentation evaluation of both: lungs and nodules. 

## Reference to official issue
This address #143

## How Has This Been Tested?
Unit tests were created for each metric and ran over block-typed input.

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well