### PR TITLE
Fixing error unhandled promise rejection #162, removing VueResource

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 .*
 !.env
 !setup.cfg
-node_modules
+interface/frontend/node_modules
 npm-debug.log

--- a/interface/frontend/build/dev-server.js
+++ b/interface/frontend/build/dev-server.js
@@ -68,7 +68,7 @@ devMiddleware.waitUntilValid(() => {
   console.log('> Listening at ' + uri + '\n')
   // when env is testing, don't need open it
   if (autoOpenBrowser && process.env.NODE_ENV !== 'testing') {
-    opn(uri)
+    opn(uri).catch(() => {})
   }
   _resolve()
 })

--- a/interface/frontend/package.json
+++ b/interface/frontend/package.json
@@ -14,8 +14,7 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"
   },
   "dependencies": {
-    "vue": "^2.4.2",
-    "vue-resource": "^1.3.4"
+    "vue": "^2.4.2"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.2",

--- a/interface/frontend/src/components/Candidate.vue
+++ b/interface/frontend/src/components/Candidate.vue
@@ -68,24 +68,22 @@ export default {
       this.isOpen = !this.isOpen
     },
     mark (candidate) {
-      this.$axios.get(candidate.url + 'mark').then(
-        (response) => {
+      this.$axios.get(candidate.url + 'mark')
+        .then((response) => {
           console.log(response)
-        },
-        () => {
-          // error callback
-        }
-      )
+        })
+        .catch(() => {
+          // TODO: error callback
+        })
     },
     dismiss (candidate) {
-      this.$axios.get(candidate.url + 'dismiss').then(
-        (response) => {
+      this.$axios.get(candidate.url + 'dismiss')
+        .then((response) => {
           console.log(response)
-        },
-        () => {
-          // error callback
-        }
-      )
+        })
+        .catch(() => {
+          // TODO: error callback
+        })
     }
   }
 }

--- a/interface/frontend/src/components/CandidateList.vue
+++ b/interface/frontend/src/components/CandidateList.vue
@@ -33,14 +33,13 @@ export default {
   },
   methods: {
     fetchCandidates () {
-      this.$axios.get('/api/candidates').then(
-        (response) => {
+      this.$axios.get('/api/candidates')
+        .then((response) => {
           this.candidates = response.data
-        },
-        () => {
-          // error callback
-        }
-      )
+        })
+        .catch(() => {
+          // TODO: error callback
+        })
     }
   }
 }

--- a/interface/frontend/src/components/ImageSeries.vue
+++ b/interface/frontend/src/components/ImageSeries.vue
@@ -99,12 +99,12 @@
     },
     methods: {
       fetchData () {
-        this.$http.get('/api/images/').then(
-          (response) => {
+        this.$axios.get('/api/images/')
+          .then((response) => {
             this.availableSeries = response.body
-          },
-          () => {
-            // error callback
+          })
+          .catch(() => {
+            // TODO: handle error
           })
       },
       selectSeries (series) {
@@ -112,14 +112,13 @@
         this.selected = series
       },
       fetchAvailableImages () {
-        this.$http.get('/api/images/available').then(
-          (response) => {
+        this.$axios.get('/api/images/available')
+          .then((response) => {
             this.directories = response.body.directories
-          },
-          () => {
-            // error callback
-          }
-        )
+          })
+          .catch(() => {
+            // TODO: handle error
+          })
       }
     }
   }

--- a/interface/frontend/src/components/Nodule.vue
+++ b/interface/frontend/src/components/Nodule.vue
@@ -48,12 +48,13 @@ export default {
       this.isOpen = !this.isOpen
     },
     update (nodule) {
-      this.$axios.put(nodule.url, { lung_orientation: this.selected }).then((response) => {
-        console.log(response)
-      },
-      () => {
-        // error callback
-      })
+      this.$axios.put(nodule.url, { lung_orientation: this.selected })
+        .then((response) => {
+          console.log(response)
+        })
+        .catch(() => {
+          // TODO: error callback
+        })
     }
   }
 }

--- a/interface/frontend/src/components/NoduleList.vue
+++ b/interface/frontend/src/components/NoduleList.vue
@@ -33,14 +33,13 @@ export default {
   },
   methods: {
     fetchNodules () {
-      this.$axios.get('/api/nodules.json').then(
-        (response) => {
+      this.$axios.get('/api/nodules.json')
+        .then((response) => {
           this.nodules = response.data
-        },
-        () => {
-          // error callback
-        }
-      )
+        })
+        .catch(() => {
+          // TODO: error callback
+        })
     }
   }
 }

--- a/interface/frontend/src/main.js
+++ b/interface/frontend/src/main.js
@@ -1,5 +1,4 @@
 import Vue from 'vue'
-import VueResource from 'vue-resource'
 import VueRouter from 'vue-router'
 import router from './routes'
 import constants from './constants'
@@ -10,7 +9,6 @@ import './assets/css/font-awesome.min.css'
 import './assets/css/project.css'
 import './assets/js/ie10-viewport-bug-workaround.js'
 
-Vue.use(VueResource)
 Vue.use(VueRouter)
 Vue.prototype.$constants = constants
 Vue.prototype.$axios = axios.create({


### PR DESCRIPTION
as described in #162 with node 8 an error is thrown after starting the vuejs dev-server. This is caused by the dev-server trying to start a browser window inside the docker container which leads to a rejected promise.

This PR fixes this issues. Additionally it improves the following:
* remove VueResource (we use axios for http requests as i understood, therefore VueResource is not needed anymore)
* fix current axios requests to also handle rejected promises correctly with catch statements
* add correct node_modules path to .dockerignore