### PR TITLE
#157 Listed available routes

### DIFF
--- a/interface/config/urls.py
+++ b/interface/config/urls.py
@@ -4,9 +4,11 @@ from django.conf.urls import (
     url
 )
 from django.views.static import serve
+from django.views.generic import RedirectView
 
 urlpatterns = (
     url(r'^api/', include('backend.api.urls', namespace='')),
+    url(r'^', RedirectView.as_view(url='api/'), name="available-routes"),
 )
 
 if settings.DEBUG:


### PR DESCRIPTION
This `http://0.0.0.0:8000/` route to a page listing all the available routes.

## Description
`http://0.0.0.0:8000/` redirect to `/api/routes` which in turn will return the dictionary of available links. 

## Reference to official issue
This addresses #157.

## Motivation and Context
Currently, navigating to `http://0.0.0.0:8000/` returns a 404 error.

## Screenshots:
The API and JSON response:
![screenshot from 2017-10-19 16-46-23](https://user-images.githubusercontent.com/9470024/31777042-534d5a7e-b4ed-11e7-88a8-af63ad8be610.png)
![screenshot from 2017-10-19 16-47-42](https://user-images.githubusercontent.com/9470024/31777045-539a15ee-b4ed-11e7-8d12-910e27194ff3.png)

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well


