### PR TITLE
#158 Hide hidden files

### DIFF
--- a/interface/frontend/package.json
+++ b/interface/frontend/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"
   },
   "dependencies": {
+    "vue-resource": "^1.3.4",
     "vue": "^2.4.2"
   },
   "devDependencies": {

--- a/interface/frontend/src/components/ImageSeries.vue
+++ b/interface/frontend/src/components/ImageSeries.vue
@@ -99,7 +99,7 @@
     },
     methods: {
       fetchData () {
-        this.$axios.get('/api/images/')
+        this.$http.get('/api/images/')
           .then((response) => {
             this.availableSeries = response.body
           })
@@ -112,7 +112,7 @@
         this.selected = series
       },
       fetchAvailableImages () {
-        this.$axios.get('/api/images/available')
+        this.$http.get('/api/images/available')
           .then((response) => {
             this.directories = response.body.directories
           })

--- a/interface/frontend/src/main.js
+++ b/interface/frontend/src/main.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import VueResource from 'vue-resource'
 import VueRouter from 'vue-router'
 import router from './routes'
 import constants from './constants'
@@ -9,6 +10,7 @@ import './assets/css/font-awesome.min.css'
 import './assets/css/project.css'
 import './assets/js/ie10-viewport-bug-workaround.js'
 
+Vue.use(VueResource)
 Vue.use(VueRouter)
 Vue.prototype.$constants = constants
 Vue.prototype.$axios = axios.create({


### PR DESCRIPTION
Filtering out the hidden files from the Vue frontend.

During working over this PR I've stumbled upon the unexpectable behaviour in `src/components/ImageSeries.vue`:
```javascript
[Vue warn]: Error in render: "TypeError: _vm.availableSeries is undefined"

found in

---> <ImageSeries> at src/components/ImageSeries.vue
       <OpenImage> at src/views/OpenImage.vue
         <App> at src/App.vue
           <Root>
```
Though the response of the `/api/images/available` was sustainable and in a proper format. It took a while from me to figure out that this behaviour was introduced by the PR #171, specifically by the exchange `$http` on `$axios` ([1](https://github.com/concept-to-clinic/concept-to-clinic/pull/171/files?diff=unified#diff-ff7a640b74e49c1a5b1dbb329689f4b7R102) and [2](https://github.com/concept-to-clinic/concept-to-clinic/pull/171/files?diff=unified#diff-ff7a640b74e49c1a5b1dbb329689f4b7R115) diffs). Thus I roll back these changes, of course, with no disruption from `UnhandledPromiseRejection`. The output of `docker-compose -f local.yml up vue` does not contain errors: 
```bash
vue_1            | [HPM] Proxy created: /  ->  http://interface:8000
vue_1            | > Starting dev server...
vue_1            |  DONE  Compiled successfully in 3260ms02:15:12
vue_1            | 
vue_1            | > Listening at http://0.0.0.0:8080
vue_1            | 
[]
```
## Description
The filtering is done on the backend side. Since there is nothing like `os.ishidden` I've decided to not over complicate and wrote the static function [`ImageAvailableApiView.is_hidden`](https://github.com/concept-to-clinic/concept-to-clinic/compare/master...vessemer:158_hide_hidden_files?expand=1#diff-500c04290e5206134d43cf7c48c3976bR80).

## Reference to official issue
This addresses the issue #158.

## Comparison:
<!--- Provide a general summary of your changes in the Title above -->
![screenshot from 2017-10-21 04-00-23](https://user-images.githubusercontent.com/9470024/31847012-6a455182-b614-11e7-8909-328468764a91.png)
![screenshot from 2017-10-21 03-47-12](https://user-images.githubusercontent.com/9470024/31847005-429d5170-b614-11e7-8ae7-8de4ac77997a.png)

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well