### PR TITLE
#179 DICOM image viewer

### DIFF
--- a/interface/frontend/package.json
+++ b/interface/frontend/package.json
@@ -81,6 +81,8 @@
     "vue-router": "^2.7.0",
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.4.2",
+    "cornerstone-core": " 0.13.0",
+    "q": "^1.5.1",
     "webpack": "^2.6.1",
     "webpack-bundle-analyzer": "^2.2.1",
     "webpack-dev-middleware": "^1.10.0",

--- a/interface/frontend/package.json
+++ b/interface/frontend/package.json
@@ -82,7 +82,6 @@
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.4.2",
     "cornerstone-core": " 0.13.0",
-    "q": "^1.5.1",
     "webpack": "^2.6.1",
     "webpack-bundle-analyzer": "^2.2.1",
     "webpack-dev-middleware": "^1.10.0",

--- a/interface/frontend/src/components/open-image/ImageSeries.vue
+++ b/interface/frontend/src/components/open-image/ImageSeries.vue
@@ -35,8 +35,9 @@
           <div class="card-header">
             Import image series
           </div>
-          <div class="card-block">
-            <tree-view class="item" :model="directories"></tree-view>
+          <div class="card-block left">
+            <tree-view class="item left" :model="directories"></tree-view>
+            <open-dicom class="right"></open-dicom>
           </div>
         </div>
       </div>
@@ -77,10 +78,12 @@
 
 <script>
   import TreeView from './TreeView'
+  import OpenDicom from './OpenDICOM'
 
   export default {
     components: {
-      TreeView
+      TreeView,
+      OpenDicom
     },
     data () {
       return {
@@ -125,4 +128,10 @@
 </script>
 
 <style lang="scss" scoped>
+  .left {
+    float: left;
+  }
+  .right {
+    float: right;
+  }
 </style>

--- a/interface/frontend/src/components/open-image/ImageSeries.vue
+++ b/interface/frontend/src/components/open-image/ImageSeries.vue
@@ -37,7 +37,7 @@
           </div>
           <div class="card-block left">
             <tree-view class="item left" :model="directories"></tree-view>
-            <open-dicom class="right"></open-dicom>
+            <open-dicom class="right" :view="preview"></open-dicom>
           </div>
         </div>
       </div>
@@ -77,6 +77,7 @@
 </template>
 
 <script>
+  import { EventBus } from '../../main.js'
   import TreeView from './TreeView'
   import OpenDicom from './OpenDICOM'
 
@@ -92,6 +93,12 @@
           name: 'root',
           children: []
         },
+        preview: {
+          type: 'DICOM',
+          prefixCS: ':/',
+          prefixUrl: '/api/images/metadata?dicom_location=/',
+          path: ''
+        },
         selected: null,
         showImport: false
       }
@@ -99,6 +106,12 @@
     created () {
       this.fetchData()
       this.fetchAvailableImages()
+    },
+    mounted: function () {
+      EventBus.$on('dicom-selection', (path) => {
+        this.preview.path = path
+        console.log(this.preview)
+      })
     },
     methods: {
       fetchData () {

--- a/interface/frontend/src/components/open-image/OpenDICOM.vue
+++ b/interface/frontend/src/components/open-image/OpenDICOM.vue
@@ -1,0 +1,132 @@
+<template>
+  <div class="container">
+    <div class="col-xs-6">
+      <div class="DICOM-container">
+        <div class="DICOM" ref="DICOM"></div>
+      </div>
+      <p>{{ dicom.imageId}}</p>>
+    </div>
+  </div>
+</template>
+
+<script>
+  var cornerstone = require('cornerstone-core')
+  var Q = require('q')
+
+  export default {
+    name: 'open-dicom',
+    data () {
+      return {
+        dicom: {
+          imageId: '',
+          minPixelValue: 0,
+          maxPixelValue: 255,
+          slope: 1.0,
+          intercept: 0,
+          windowCenter: 90,
+          windowWidth: 100,
+          render: cornerstone.renderGrayscaleImage,
+          getPixelData: this.getPixelData,
+          rows: 512,
+          columns: 512,
+          height: 512,
+          width: 512,
+          color: false,
+          base64data: '',
+          columnPixelSpacing: 1,
+          rowPixelSpacing: 1,
+          sizeInBytes: 512 * 512 * 2
+        },
+        dicomUrl: 'LIDC://LIDC-IDRI-0001/1.3.6.1.4.1.14519.5.2.1.6279.6001.298806137288633453246975630178/1.3.6.1.4.1.14519.5.2.1.6279.6001.179049373636438705059720603192/-95.000000.dcm',
+        info: null,
+        csName: 'LIDC'
+      }
+    },
+    watch: {
+      info: function (val) {
+        if (val != null) {
+          this.applyMeta(val)
+          console.log(this.dicom)
+          this.loadImage(this.resolveDICOM)
+        }
+      }
+    },
+    mounted: function () {
+      this.fetchData(this.dicomUrl)
+    },
+    methods: {
+      fetchData (id) {
+        this.$axios.get('/api/images/metadata?dicom_location=/images/' + id.slice(this.csName.length + 3))
+          .then((response) => {
+            this.info = response.data
+          })
+          .catch(() => {
+            // TODO: handle error
+          })
+      },
+      applyMeta (info) {
+        this.dicom.imageId = this.dicomUrl
+        var meta = info['metadata']
+        this.dicom.base64data = info['image']
+        this.dicom.slope = meta['Rescale Slope']
+        this.dicom.rows = meta['Rows']
+        this.dicom.columns = meta['Columns']
+        this.dicom.height = meta['Rows']
+        this.dicom.width = meta['Columns']
+        this.dicom.columnPixelSpacing = meta['Pixel Spacing']['0']
+        this.dicom.rowPixelSpacing = meta['Pixel Spacing']['1']
+      },
+      str2pixelData (str) {
+        var buf = new ArrayBuffer(str.length * 2) // 2 bytes for each char
+        var bufView = new Int16Array(buf)
+        var index = 0
+        for (var i = 0, strLen = str.length; i < strLen; i += 2) {
+          var lower = str.charCodeAt(i)
+          var upper = str.charCodeAt(i + 1)
+          bufView[index] = lower + (upper << 8)
+          index++
+        }
+        return bufView
+      },
+      getPixelData () {
+        var pixelDataAsString = window.atob(this.dicom.base64data)
+        var pixelData = this.str2pixelData(pixelDataAsString)
+        return pixelData
+      },
+      resolveDICOM (imageId) {
+        var deferred = Q.defer()
+        deferred.resolve(this.dicom)
+        return deferred.promise
+      },
+      loadImage (resolve) {
+        cornerstone.registerImageLoader('LIDC', resolve)
+        var element = this.$refs.DICOM
+        console.log(element)
+
+        cornerstone.enable(element)
+        console.log(resolve())
+        cornerstone.loadImage(this.dicom.imageId).then(function (image) {
+          cornerstone.displayImage(element, image)
+        })
+      }
+    }
+  }
+</script>
+
+<style lang="scss" scoped>
+  .DICOM-container {
+    width:512px;
+    height:512px;
+    position:relative;
+    display:inline-block;
+    color:white;
+  }
+
+  .DICOM {
+    width:512px;
+    height:512px;
+    top:0px;
+    left:0px;
+    position:absolute;
+  }
+</style>

--- a/interface/frontend/src/components/open-image/OpenDICOM.vue
+++ b/interface/frontend/src/components/open-image/OpenDICOM.vue
@@ -6,8 +6,8 @@
 
 <script>
   import { EventBus } from '../../main.js'
-  var cornerstone = require('cornerstone-core')
-  var Q = require('q')
+  const cornerstone = require('cornerstone-core')
+  const Q = require('q')
 
   export default {
     name: 'open-dicom',
@@ -69,7 +69,7 @@
           })
       },
       applyMeta (info) {
-        var meta = info['metadata']
+        const meta = info['metadata']
         this.dicom.base64data = info['image']
         this.dicom.slope = meta['Rescale Slope']
         this.dicom.rows = meta['Rows']
@@ -80,30 +80,28 @@
         this.dicom.rowPixelSpacing = meta['Pixel Spacing']['1']
       },
       str2pixelData (str) {
-        var buf = new ArrayBuffer(str.length * 2) // 2 bytes for each char
-        var bufView = new Int16Array(buf)
-        var index = 0
-        for (var i = 0, strLen = str.length; i < strLen; i += 2) {
-          var lower = str.charCodeAt(i)
-          var upper = str.charCodeAt(i + 1)
-          bufView[index] = lower + (upper << 8)
+        let buf = new ArrayBuffer(str.length * 2) // 2 bytes for each char
+        let bufView = new Int16Array(buf)
+        let index = 0
+        for (let i = 0, strLen = str.length; i < strLen; i += 2) {
+          bufView[index] = str.charCodeAt(i) + (str.charCodeAt(i + 1) << 8)
           index++
         }
         return bufView
       },
       getPixelData () {
-        var pixelDataAsString = window.atob(this.dicom.base64data)
-        var pixelData = this.str2pixelData(pixelDataAsString)
+        let pixelDataAsString = window.atob(this.dicom.base64data)
+        let pixelData = this.str2pixelData(pixelDataAsString)
         return pixelData
       },
       resolveDICOM (imageId) {
-        var deferred = Q.defer()
+        const deferred = Q.defer()
         deferred.resolve(this.dicom)
         return deferred.promise
       },
       loadImage (resolve) {
         cornerstone.registerImageLoader(this.csName, resolve)
-        var element = this.$refs.DICOM
+        const element = this.$refs.DICOM
         console.log(element)
 
         cornerstone.enable(element)

--- a/interface/frontend/src/components/open-image/OpenDICOM.vue
+++ b/interface/frontend/src/components/open-image/OpenDICOM.vue
@@ -7,7 +7,6 @@
 
 <script>
   const cornerstone = require('cornerstone-core')
-  const Q = require('q')
 
   export default {
     name: 'open-dicom',
@@ -64,9 +63,9 @@
       display () {
         return this.dicom.then((dicom) => {
           let resolve = function () {
-            const deferred = Q.defer()
-            deferred.resolve(dicom)
-            return deferred.promise
+            return new Promise(function (resolve) {
+              resolve(dicom)
+            })
           }
           const element = this.$refs.DICOM
           this.initCS(element)

--- a/interface/frontend/src/components/open-image/TreeView.vue
+++ b/interface/frontend/src/components/open-image/TreeView.vue
@@ -15,14 +15,17 @@
                    :key="child.name"
                    :model="child"
         ></tree-view>
-        <li v-for="file in model.files" class="text-muted">{{ file.name }}</li>
+        <li @click="select(file.path)" v-for="file in model.files" class="text-muted">{{ file.name }}</li>
       </ul>
     </li>
   </ul>
 </template>
 
+
+
 <script>
   import TreeView from './TreeView'
+  import { EventBus } from '../../main.js'
 
   export default {
     name: 'tree-view',
@@ -70,6 +73,9 @@
     methods: {
       toggle: function () {
         this.$set(this, 'open', !this.open)
+      },
+      select: function (path) {
+        EventBus.$emit('dicom-selection', path)
       }
     }
   }

--- a/interface/frontend/src/main.js
+++ b/interface/frontend/src/main.js
@@ -9,7 +9,7 @@ import './assets/css/bootstrap.min.css'
 import './assets/css/font-awesome.min.css'
 import './assets/css/project.css'
 import './assets/js/ie10-viewport-bug-workaround.js'
-
+export const EventBus = new Vue()
 Vue.use(VueResource)
 Vue.use(VueRouter)
 Vue.prototype.$constants = constants

--- a/interface/frontend/src/views/OpenImage.vue
+++ b/interface/frontend/src/views/OpenImage.vue
@@ -1,18 +1,15 @@
 <template>
   <div class="container">
     <image-series></image-series>
-    <open-dicom></open-dicom>
   </div>
 </template>
 
 <script>
 import ImageSeries from '../components/open-image/ImageSeries'
-import OpenDicom from '../components/open-image/OpenDICOM'
 
 export default {
   components: {
-    ImageSeries,
-    OpenDicom
+    ImageSeries
   },
   name: 'open-image'
 }

--- a/interface/frontend/src/views/OpenImage.vue
+++ b/interface/frontend/src/views/OpenImage.vue
@@ -1,137 +1,22 @@
 <template>
   <div class="container">
     <image-series></image-series>
-    <div class="col-xs-6">
-      <div class="DICOM-container">
-        <div class="DICOM" ref="DICOM"></div>
-      </div>
-      <p>{{ dicom.imageId}}</p>>
-    </div>
+    <open-dicom></open-dicom>
   </div>
 </template>
 
 <script>
 import ImageSeries from '../components/open-image/ImageSeries'
-var cornerstone = require('cornerstone-core')
-var Q = require('q')
+import OpenDicom from '../components/open-image/OpenDICOM'
 
 export default {
   components: {
-    ImageSeries
+    ImageSeries,
+    OpenDicom
   },
-  name: 'dicom-view',
-  data () {
-    return {
-      dicom: {
-        imageId: '',
-        minPixelValue: 0,
-        maxPixelValue: 255,
-        slope: 1.0,
-        intercept: 0,
-        windowCenter: 90,
-        windowWidth: 100,
-        render: cornerstone.renderGrayscaleImage,
-        getPixelData: this.getPixelData,
-        rows: 512,
-        columns: 512,
-        height: 512,
-        width: 512,
-        color: false,
-        base64data: '',
-        columnPixelSpacing: 1,
-        rowPixelSpacing: 1,
-        sizeInBytes: 512 * 512 * 2
-      },
-      dicomUrl: 'LIDC://LIDC-IDRI-0001/1.3.6.1.4.1.14519.5.2.1.6279.6001.298806137288633453246975630178/1.3.6.1.4.1.14519.5.2.1.6279.6001.179049373636438705059720603192/-95.000000.dcm',
-      info: null,
-      csName: 'LIDC'
-    }
-  },
-  watch: {
-    info: function (val) {
-      if (val != null) {
-        this.applyMeta(val)
-        console.log(this.dicom)
-        this.loadImage(this.resolveDICOM)
-      }
-    }
-  },
-  mounted: function () {
-    this.fetchData(this.dicomUrl)
-  },
-  methods: {
-    fetchData (id) {
-      this.$axios.get('/api/images/metadata?dicom_location=/images/' + id.slice(this.csName.length + 3))
-        .then((response) => {
-          this.info = response.data
-        })
-        .catch(() => {
-          // TODO: handle error
-        })
-    },
-    applyMeta (info) {
-      this.dicom.imageId = this.dicomUrl
-      var meta = info['metadata']
-      this.dicom.base64data = info['image']
-      this.dicom.slope = meta['Rescale Slope']
-      this.dicom.rows = meta['Rows']
-      this.dicom.columns = meta['Columns']
-      this.dicom.height = meta['Rows']
-      this.dicom.width = meta['Columns']
-      this.dicom.columnPixelSpacing = meta['Pixel Spacing']['0']
-      this.dicom.rowPixelSpacing = meta['Pixel Spacing']['1']
-    },
-    str2pixelData (str) {
-      var buf = new ArrayBuffer(str.length * 2) // 2 bytes for each char
-      var bufView = new Int16Array(buf)
-      var index = 0
-      for (var i = 0, strLen = str.length; i < strLen; i += 2) {
-        var lower = str.charCodeAt(i)
-        var upper = str.charCodeAt(i + 1)
-        bufView[index] = lower + (upper << 8)
-        index++
-      }
-      return bufView
-    },
-    getPixelData () {
-      var pixelDataAsString = window.atob(this.dicom.base64data)
-      var pixelData = this.str2pixelData(pixelDataAsString)
-      return pixelData
-    },
-    resolveDICOM (imageId) {
-      var deferred = Q.defer()
-      deferred.resolve(this.dicom)
-      return deferred.promise
-    },
-    loadImage (resolve) {
-      cornerstone.registerImageLoader('LIDC', resolve)
-      var element = this.$refs.DICOM
-      console.log(element)
-
-      cornerstone.enable(element)
-      console.log(resolve())
-      cornerstone.loadImage(this.dicom.imageId).then(function (image) {
-        cornerstone.displayImage(element, image)
-      })
-    }
-  }
+  name: 'open-image'
 }
 </script>
 
 <style lang="scss" scoped>
-  .DICOM-container {
-    width:512px;
-    height:512px;
-    position:relative;
-    display:inline-block;
-    color:white;
-  }
-
-  .DICOM {
-    width:512px;
-    height:512px;
-    top:0px;
-    left:0px;
-    position:absolute;
-  }
 </style>

--- a/interface/frontend/src/views/OpenImage.vue
+++ b/interface/frontend/src/views/OpenImage.vue
@@ -1,13 +1,137 @@
 <template>
-  <image-series></image-series>
+  <div class="container">
+    <image-series></image-series>
+    <div class="col-xs-6">
+      <div class="DICOM-container">
+        <div class="DICOM" ref="DICOM"></div>
+      </div>
+      <p>{{ dicom.imageId}}</p>>
+    </div>
+  </div>
 </template>
 
 <script>
 import ImageSeries from '../components/open-image/ImageSeries'
+var cornerstone = require('cornerstone-core')
+var Q = require('q')
 
 export default {
   components: {
     ImageSeries
+  },
+  name: 'dicom-view',
+  data () {
+    return {
+      dicom: {
+        imageId: '',
+        minPixelValue: 0,
+        maxPixelValue: 255,
+        slope: 1.0,
+        intercept: 0,
+        windowCenter: 90,
+        windowWidth: 100,
+        render: cornerstone.renderGrayscaleImage,
+        getPixelData: this.getPixelData,
+        rows: 512,
+        columns: 512,
+        height: 512,
+        width: 512,
+        color: false,
+        base64data: '',
+        columnPixelSpacing: 1,
+        rowPixelSpacing: 1,
+        sizeInBytes: 512 * 512 * 2
+      },
+      dicomUrl: 'LIDC://LIDC-IDRI-0001/1.3.6.1.4.1.14519.5.2.1.6279.6001.298806137288633453246975630178/1.3.6.1.4.1.14519.5.2.1.6279.6001.179049373636438705059720603192/-95.000000.dcm',
+      info: null,
+      csName: 'LIDC'
+    }
+  },
+  watch: {
+    info: function (val) {
+      if (val != null) {
+        this.applyMeta(val)
+        console.log(this.dicom)
+        this.loadImage(this.resolveDICOM)
+      }
+    }
+  },
+  mounted: function () {
+    this.fetchData(this.dicomUrl)
+  },
+  methods: {
+    fetchData (id) {
+      this.$axios.get('/api/images/metadata?dicom_location=/images/' + id.slice(this.csName.length + 3))
+        .then((response) => {
+          this.info = response.data
+        })
+        .catch(() => {
+          // TODO: handle error
+        })
+    },
+    applyMeta (info) {
+      this.dicom.imageId = this.dicomUrl
+      var meta = info['metadata']
+      this.dicom.base64data = info['image']
+      this.dicom.slope = meta['Rescale Slope']
+      this.dicom.rows = meta['Rows']
+      this.dicom.columns = meta['Columns']
+      this.dicom.height = meta['Rows']
+      this.dicom.width = meta['Columns']
+      this.dicom.columnPixelSpacing = meta['Pixel Spacing']['0']
+      this.dicom.rowPixelSpacing = meta['Pixel Spacing']['1']
+    },
+    str2pixelData (str) {
+      var buf = new ArrayBuffer(str.length * 2) // 2 bytes for each char
+      var bufView = new Int16Array(buf)
+      var index = 0
+      for (var i = 0, strLen = str.length; i < strLen; i += 2) {
+        var lower = str.charCodeAt(i)
+        var upper = str.charCodeAt(i + 1)
+        bufView[index] = lower + (upper << 8)
+        index++
+      }
+      return bufView
+    },
+    getPixelData () {
+      var pixelDataAsString = window.atob(this.dicom.base64data)
+      var pixelData = this.str2pixelData(pixelDataAsString)
+      return pixelData
+    },
+    resolveDICOM (imageId) {
+      var deferred = Q.defer()
+      deferred.resolve(this.dicom)
+      return deferred.promise
+    },
+    loadImage (resolve) {
+      cornerstone.registerImageLoader('LIDC', resolve)
+      var element = this.$refs.DICOM
+      console.log(element)
+
+      cornerstone.enable(element)
+      console.log(resolve())
+      cornerstone.loadImage(this.dicom.imageId).then(function (image) {
+        cornerstone.displayImage(element, image)
+      })
+    }
   }
 }
 </script>
+
+<style lang="scss" scoped>
+  .DICOM-container {
+    width:512px;
+    height:512px;
+    position:relative;
+    display:inline-block;
+    color:white;
+  }
+
+  .DICOM {
+    width:512px;
+    height:512px;
+    top:0px;
+    left:0px;
+    position:absolute;
+  }
+</style>


### PR DESCRIPTION
The ability to show DICOM images is one of the most important parts for this project. There are existing libraries that provide a way to show DICOM images that can help with this task. It were two main candidates with proper library to choose from: [ivmartel](https://github.com/ivmartel) and [chafey](https://github.com/chafey). The decision was made to use the [cornerstone](https://github.com/chafey/cornerstone) library for the reason that it flexible and can provide the project with ability to show images in an interactive way. It is also was much easier to use with VueJS than its competitor.

Two main difficulties were met during the work on this issue. The first one was the problem with pixelData serialization. It took some time before a good solution was found.

The second problem was to make library work correctly with VueJS. Choosing the most appropriate llibrary also refers to this problem. A lot of time was spent on testing and studying different libraries and browsing repositories before the appropriate solution was found.

## Description

This is the implementation of DICOM image viewer that was made with the help of [cornerstone](https://github.com/chafey/cornerstone) and [cornerstoneTools](https://github.com/chafey/cornerstoneTools). The image is being taken by the part of the url that adresses it.

## Reference to official issue
This address #179

## Motivation and Context
There is a strong need in the way of showing DICOM imagery. It is impossible to make that project at least somehow usable by common people without DICOMs actually being shown. Furthermore, issues [#148](https://github.com/concept-to-clinic/concept-to-clinic/issues/148) and [#150](https://github.com/concept-to-clinic/concept-to-clinic/issues/150) depend on it.

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well