### PR TITLE
#148 Manipulations with DICOM vue

### DIFF
--- a/interface/frontend/package.json
+++ b/interface/frontend/package.json
@@ -83,7 +83,7 @@
     "vue-template-compiler": "^2.4.2",
     "cornerstone-core": " 0.13.0",
     "cornerstone-tools": " 0.10.0",
-    "jquery": "^3.2.1",
+    "jquery-slim": "^3.0.0",
     "webpack": "^2.6.1",
     "webpack-bundle-analyzer": "^2.2.1",
     "webpack-dev-middleware": "^1.10.0",

--- a/interface/frontend/package.json
+++ b/interface/frontend/package.json
@@ -82,6 +82,8 @@
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.4.2",
     "cornerstone-core": " 0.13.0",
+    "cornerstone-tools": " 0.10.0",
+    "jquery": "^3.2.1",
     "webpack": "^2.6.1",
     "webpack-bundle-analyzer": "^2.2.1",
     "webpack-dev-middleware": "^1.10.0",

--- a/interface/frontend/src/components/open-image/ImageSeries.vue
+++ b/interface/frontend/src/components/open-image/ImageSeries.vue
@@ -95,9 +95,9 @@
         },
         preview: {
           type: 'DICOM',
-          prefixCS: ':/',
+          prefixCS: '://',
           prefixUrl: '/api/images/metadata?dicom_location=/',
-          path: ''
+          paths: []
         },
         selected: null,
         showImport: false
@@ -109,7 +109,7 @@
     },
     mounted: function () {
       EventBus.$on('dicom-selection', (path) => {
-        this.preview.path = path
+        this.preview.paths = path
         console.log(this.preview)
       })
     },

--- a/interface/frontend/src/components/open-image/OpenDICOM.vue
+++ b/interface/frontend/src/components/open-image/OpenDICOM.vue
@@ -8,7 +8,7 @@
 <script>
   const cornerstone = require('cornerstone-core')
   const cornerstoneTools = require('cornerstone-tools')
-  const jquery = require('jquery')
+  const jquery = require('jquery-slim')
   cornerstoneTools.external.cornerstone = cornerstone
   cornerstoneTools.external.$ = jquery
 

--- a/interface/frontend/src/components/open-image/OpenDICOM.vue
+++ b/interface/frontend/src/components/open-image/OpenDICOM.vue
@@ -7,6 +7,10 @@
 
 <script>
   const cornerstone = require('cornerstone-core')
+  const cornerstoneTools = require('cornerstone-tools')
+  const jquery = require('jquery')
+  cornerstoneTools.external.cornerstone = cornerstone
+  cornerstoneTools.external.$ = jquery
 
   export default {
     name: 'open-dicom',
@@ -17,25 +21,46 @@
           type: 'DICOM',
           prefixCS: ':/',
           prefixUrl: null,
-          path: null
+          paths: []
         }
       }
     },
     data () {
       return {
-        base64data: null
+        stack: {
+          currentImageIdIndex: 0,
+          imageIds: []
+        },
+        base64data: null,
+        pool: []
+      }
+    },
+    watch: {
+      'view.paths': function (val) {
+        const element = this.$refs.DICOM
+        this.pool = []
+        this.stack.currentImageIdIndex = 0
+        this.stack.imageIds = this.view.paths.map((path) => {
+          return this.view.type + this.view.prefixCS + path
+        }, this)
+        cornerstone.disable(element)
+        this.initCS(element)
       }
     },
     computed: {
       async info () {
-        const response = await this.$axios.get(this.view.prefixUrl + this.view.path)
-        return response.data
+        if (this.pool.length <= this.stack.currentImageIdIndex) {
+          const hola = await this.$axios.get(this.view.prefixUrl + this.view.paths[this.stack.currentImageIdIndex])
+          this.pool.push(hola)
+        }
+        return this.pool[this.stack.currentImageIdIndex]
       },
       async dicom () {
-        const info = await this.info
+        let info = await this.info
+        info = info.data
         this.base64data = info.image
         return {
-          imageId: this.view.type + this.view.prefixCS + this.view.path,
+          imageId: this.stack.imageIds[this.stack.currentImageIdIndex],
           slope: info.metadata['Rescale Slope'],
           rows: info.metadata['Rows'],
           columns: info.metadata['Columns'],
@@ -57,8 +82,6 @@
       async display () {
         const element = this.$refs.DICOM
         const dicom = await this.dicom
-        this.initCS(element)
-
         cornerstone.registerImageLoader(this.view.type, () => {
           return new Promise((resolve) => { resolve(dicom) })
         })
@@ -73,6 +96,13 @@
           cornerstone.getEnabledElement(element)
         } catch (e) {
           cornerstone.enable(element)
+          cornerstoneTools.mouseInput.enable(element)
+          cornerstoneTools.addStackStateManager(element, ['stack'])
+          cornerstoneTools.addToolState(element, 'stack', this.stack)
+          cornerstoneTools.stackScroll.activate(element, 1)
+          cornerstoneTools.stackScrollWheel.activate(element)
+          cornerstoneTools.scrollIndicator.enable(element)
+          cornerstoneTools.wwwc.activate(element, 1)
         }
       },
       str2pixelData (str) {

--- a/interface/frontend/src/components/open-image/TreeView.vue
+++ b/interface/frontend/src/components/open-image/TreeView.vue
@@ -15,7 +15,7 @@
                    :key="child.name"
                    :model="child"
         ></tree-view>
-        <li @click="select(file.path)" v-for="file in model.files" class="text-muted">{{ file.name }}</li>
+        <li @click="select()" v-for="file in model.files" class="text-muted">{{ file.name }}</li>
       </ul>
     </li>
   </ul>
@@ -74,8 +74,8 @@
       toggle: function () {
         this.$set(this, 'open', !this.open)
       },
-      select: function (path) {
-        EventBus.$emit('dicom-selection', path)
+      select: function () {
+        EventBus.$emit('dicom-selection', this.model.files.map((file) => { return file.path }))
       }
     }
   }


### PR DESCRIPTION
Manipulations over DICOM such as `scroll`, `window width` / `window centre`, etc. series were requested by both #148 and #149. Were implemented by [`cornerstoneTools`](https://github.com/chafey/cornerstoneTools). It took a while to distinguish sustainable versions, compatible with this project:
```javascript
    "cornerstone-core": " 0.13.0",
    "cornerstone-tools": " 0.10.0",
    "jquery": "^3.2.1"
```
 I'd like to separate them from drawing features and made them part of [`OpenDICOM`](https://github.com/concept-to-clinic/concept-to-clinic/compare/master...vessemer:148_detect_and_select?expand=1#diff-70d179422138a3042c2135a282065626), still any suggestions are highly appreciated!

## Description
In this PR `scroll`, `window width` / `window centre` DICOM manipulators were implemented.

## Reference to official issue
This partially addresses #148 

## Screanshots
### Scrolling:
![peek 2017-10-31 04-13](https://user-images.githubusercontent.com/9470024/32206266-6a8a081c-bdf4-11e7-8007-1067b14c408d.gif)
### WWWC:
![peek 2017-10-31 04-14](https://user-images.githubusercontent.com/9470024/32206267-6ab3f53c-bdf4-11e7-8c39-22e18c0efd68.gif)
P.S. there are errors in `cornerstone-tools`' [README](https://github.com/chafey/cornerstoneTools/blame/master/README.md#L51-L55) should be `cornerstoneTools.external` not in plural.
## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well