### PR TITLE
#159 Docker: Reuse Caches

### DIFF
--- a/compose/base/Dockerfile-dev
+++ b/compose/base/Dockerfile-dev
@@ -1,0 +1,26 @@
+FROM ubuntu:rolling
+ENV PYTHONUNBUFFERED 1
+RUN apt-get update && apt-get install -y tcl tk python3.6 python3.6-tk wget python-opencv
+RUN wget https://bootstrap.pypa.io/get-pip.py
+RUN python3.6 get-pip.py
+
+# Interface
+COPY ./interface/requirements /requirements/interface
+RUN pip install -U pip
+RUN pip install -r /requirements/interface/local.txt
+
+# Prediction
+COPY ./prediction/.pylidcrc /root/.pylidcrc
+COPY ./prediction/requirements/torch.txt /requirements/prediction/torch.txt
+RUN pip install -r /requirements/prediction/torch.txt
+COPY ./prediction/requirements/local.txt /requirements/prediction/local.txt
+RUN pip install -r /requirements/prediction/local.txt
+COPY ./prediction/requirements/base.txt /requirements/prediction/base.txt
+RUN pip install -r /requirements/prediction/base.txt
+
+# Documentation
+COPY ./docs/requirements.txt /requirements/requirements.txt
+RUN pip install -r /requirements/requirements.txt
+
+
+WORKDIR /app

--- a/compose/base/Dockerfile-dev
+++ b/compose/base/Dockerfile-dev
@@ -4,6 +4,10 @@ RUN apt-get update && apt-get install -y tcl tk python3.6 python3.6-tk wget pyth
 RUN wget https://bootstrap.pypa.io/get-pip.py
 RUN python3.6 get-pip.py
 
+# Default to Python 3.6
+RUN rm /usr/bin/python
+RUN ln -s /usr/bin/python3.6 /usr/bin/python
+
 # Interface
 COPY ./interface/requirements /requirements/interface
 RUN pip install -U pip

--- a/compose/documentation/Dockerfile-dev
+++ b/compose/documentation/Dockerfile-dev
@@ -1,3 +1,5 @@
 FROM concepttoclinic_base
 
+RUN apt-get install make
+
 WORKDIR /app

--- a/compose/documentation/Dockerfile-dev
+++ b/compose/documentation/Dockerfile-dev
@@ -1,19 +1,3 @@
-FROM python:3.6
-ENV PYTHONUNBUFFERED 1
-
-# Requirements have to be pulled and installed here, otherwise caching won't work
-COPY ./prediction/requirements/torch.txt /requirements/prediction/torch.txt
-RUN pip install -r /requirements/prediction/torch.txt
-COPY ./prediction/requirements/local.txt /requirements/prediction/local.txt
-RUN pip install -r /requirements/prediction/local.txt
-COPY ./prediction/requirements/base.txt /requirements/prediction/base.txt
-RUN pip install -r /requirements/prediction/base.txt
-
-COPY ./interface/requirements /requirements/interface
-RUN pip install -r /requirements/interface/local.txt
-
-# Documentation
-COPY ./docs/requirements.txt /requirements/requirements.txt
-RUN pip install -r /requirements/requirements.txt
+FROM concepttoclinic_base
 
 WORKDIR /app

--- a/compose/interface/Dockerfile-dev-api
+++ b/compose/interface/Dockerfile-dev-api
@@ -1,10 +1,4 @@
-FROM python:3.6
-ENV PYTHONUNBUFFERED 1
-
-# Requirements have to be pulled and installed here, otherwise caching won't work
-COPY ./interface/requirements /requirements/interface
-RUN pip install -U pip
-RUN pip install -r /requirements/interface/local.txt
+FROM concepttoclinic_base
 
 # Copy the scripts into the container
 COPY ./compose/interface/entrypoint.sh /entrypoint.sh

--- a/compose/prediction/Dockerfile-dev
+++ b/compose/prediction/Dockerfile-dev
@@ -1,16 +1,3 @@
-FROM ubuntu:rolling
-ENV PYTHONUNBUFFERED 1
-RUN apt-get update && apt-get install -y tcl tk python3.6 python3.6-tk wget python-opencv
-RUN wget https://bootstrap.pypa.io/get-pip.py
-RUN python3.6 get-pip.py
-
-# Requirements have to be pulled and installed here, otherwise caching won't work
-COPY ./prediction/.pylidcrc /root/.pylidcrc
-COPY ./prediction/requirements/torch.txt /requirements/prediction/torch.txt
-RUN pip install -r /requirements/prediction/torch.txt
-COPY ./prediction/requirements/local.txt /requirements/prediction/local.txt
-RUN pip install -r /requirements/prediction/local.txt
-COPY ./prediction/requirements/base.txt /requirements/prediction/base.txt
-RUN pip install -r /requirements/prediction/base.txt
+FROM concepttoclinic_base
 
 WORKDIR /app

--- a/interface/requirements/base.txt
+++ b/interface/requirements/base.txt
@@ -2,7 +2,7 @@ Django==1.11.3
 djangorestframework==3.6.3
 
 # Database
-psycopg2==2.7.1
+psycopg2==2.7.3.1
 
 # Config
 django-dotenv==1.4.1

--- a/local.yml
+++ b/local.yml
@@ -11,6 +11,12 @@ services:
     environment:
       - POSTGRES_USER=concepttoclinic
 
+  base:
+    build:
+      context: .
+      dockerfile: ./compose/base/Dockerfile-dev
+    container_name: base
+
   interface:
     build:
       context: .
@@ -18,6 +24,7 @@ services:
     command: /start-dev.sh
     depends_on:
       - postgres
+      - base
       - prediction
     environment:
       - POSTGRES_USER=concepttoclinic
@@ -58,6 +65,8 @@ services:
       context: .
       dockerfile: ./compose/prediction/Dockerfile-dev
     command: flask run --host=0.0.0.0 --port=8001
+    depends_on:
+      - base
     environment:
       - FLASK_DEBUG=1
       - FLASK_APP=src/factory.py
@@ -77,6 +86,7 @@ services:
     restart: always
     depends_on:
       - postgres
+      - base
     environment:
       - POSTGRES_USER=concepttoclinic
       - USE_DOCKER=yes


### PR DESCRIPTION
First, a base image is built that installs all needed pip requirements. The docker containers, that need parts of the requirements (prediction, interface and documentation services), then are built on top of that base image. Thus, building the documentation service doesn't require to install all pip requirements again resulting in a great speed-up of the container building.

## Reference to official issue
This addresses #159 

## How Has This Been Tested?
`docker-compose -f local.yml build && docker-compose -f local.yml up` builds all containers properly and fires them up.

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well

PS: Accelerated the build time on Travis from μ=23.5min ± 2.2 min (measured on the last 25 builds) to 18 min (first successful build of this branch) :tada: The time it takes to build the services locally should thus also greatly be decreased.