### PR TITLE
#161 Remove pycache directories files on build

### DIFF
--- a/compose/base/Dockerfile-dev
+++ b/compose/base/Dockerfile-dev
@@ -8,6 +8,9 @@ RUN python3.6 get-pip.py
 RUN rm /usr/bin/python
 RUN ln -s /usr/bin/python3.6 /usr/bin/python
 
+# Removing existing __pycache__ files
+RUN find . -type d -name __pycache__ -exec rm -r {} \+
+
 # Interface
 COPY ./interface/requirements /requirements/interface
 RUN pip install -U pip


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Remove all __pycache__ files when you run `docker-compose -f local.yml build prediction`.

## Description
<!--- Describe your changes in detail -->
Added a one-line code in Docker file referenced at #161  by @reubano 

## Reference to official issue
<!--- If fixing a bug, there should be an existing issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #161 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If adding a new feature or making improvements not already reflected in an official issue, please reference the relevant sections of the design doc -->
Old __pycache__ files can interfere with proper running of docker-compose -f local.yml build and may even cause the following error:
```
import file mismatch:
imported module 'app.src.tests.test_load_ct' has this __file__ attribute:
  /Volumes/Nahla/alcf/prediction/src/tests/test_load_ct.py
which is not the same as the test file we want to collect:
  /app/src/tests/test_load_ct.py
```
There should be a convenient script that can be run to remove all __pycache__ files.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run build several times without any error.


## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well