### PR TITLE
#207 expand/collapse tree on folder name click

### DIFF
--- a/interface/frontend/src/components/open-image/TreeView.vue
+++ b/interface/frontend/src/components/open-image/TreeView.vue
@@ -1,9 +1,11 @@
 <template>
   <ul>
     <li>
-      {{ model.name }}
-      <span v-if="isOpenable"  @click="toggle">
-        [{{open ? '-' : '+'}}]
+      <span @click="toggle" v-if="isOpenable">
+        {{ model.name }} [{{open ? '-' : '+'}}]
+      </span>
+      <span v-else>
+        {{ model.name }}
       </span>
       <span class="badge badge-default" v-if="hasFiles">
         {{ model.files.length }}


### PR DESCRIPTION
Clicking the directory name in the file browser (TreeView) will expand/collapse nested objects.

## Description
If folder is openable, it could be expanded/collapsed by clicking on folder name or "+/-" sign.

## Reference to official issue
#207 

## How Has This Been Tested?
Was tested manually

## Screenshots
![peek 2017-11-06 16-48](https://user-images.githubusercontent.com/17836809/32446698-5f5918fc-c312-11e7-99cd-eeb40f69a944.gif)

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well