### PR TITLE
Fixed nodule identification

### DIFF
--- a/prediction/src/algorithms/identify/src/gtr123_model.py
+++ b/prediction/src/algorithms/identify/src/gtr123_model.py
@@ -485,7 +485,7 @@ def predict(ct_path, model_path=None):
         model_path = path.join(INDENTIFY_DIR, 'assets', 'dsb2017_detector.ckpt')
 
     ct_array, meta = load_ct.load_ct(ct_path)
-    meta = load_ct.MetaImage(meta)
+    meta = load_ct.MetaData(meta)
     spacing = np.array(meta.spacing)
     masked_image, mask = filter_lungs(ct_array)
 

--- a/prediction/src/algorithms/identify/trained_model.py
+++ b/prediction/src/algorithms/identify/trained_model.py
@@ -41,6 +41,13 @@ def predict(dicom_path):
              'z': int,
              'p_nodule': float}
     """
+    
+    reader = sitk.ImageSeriesReader()
+    filenames = reader.GetGDCMSeriesFileNames(dicom_path)
+
+    if not filenames:
+        message = "The path {} doesn't contain any .mhd or .dcm files"
+        raise ValueError(message.format(dicom_path))
 
     # all required preprocssing and prediction is implemented in gtr123_model
     result = gtr123_model.predict(dicom_path)

--- a/prediction/src/algorithms/identify/trained_model.py
+++ b/prediction/src/algorithms/identify/trained_model.py
@@ -42,33 +42,9 @@ def predict(dicom_path):
              'p_nodule': float}
     """
 
-    reader = sitk.ImageSeriesReader()
-    filenames = reader.GetGDCMSeriesFileNames(dicom_path)
-
-    if not filenames:
-        message = "The path {} doesn't contain any .mhd or .dcm files"
-        raise ValueError(message.format(dicom_path))
-
-    reader.SetFileNames(reader.GetGDCMSeriesFileNames(dicom_path))
-    image = reader.Execute()
-    result = gtr123_model.predict(image)
+    # all required preprocssing and prediction is implemented in gtr123_model
+    result = gtr123_model.predict(dicom_path)
     return result
-    # if dicom_path[-1] != '/':
-    #     dicom_path += '/'
-    # dicom_files = glob.glob(dicom_path + "*.dcm")
-    # if not dicom_files:
-    #     raise EmptyDicomSeriesException
-    # patient_id = dicom.read_file(dicom_files[0]).SeriesInstanceUID
-    # z, x, y = save_lung_segments(dicom_path, patient_id)
-    # results_df = run_prediction(patient_id)
-    # results_df['coord_x'] *= x
-    # results_df['coord_y'] *= y
-    # results_df['coord_z'] *= z
-    # rescaled_results_df = results_df[['coord_x', 'coord_y', 'coord_z', 'nodule_chance']].copy()
-    # rescaled_results_df.columns = ['x', 'y', 'z', 'p_nodule']
-    # rescaled_results_df[['x', 'y', 'z']] = rescaled_results_df[['x', 'y', 'z']].astype(int)
-    # rescaled_dict = rescaled_results_df.to_dict(orient='record')
-    # return rescaled_dict
 
 
 def run_prediction(patient_id, magnification=1, ext_name="luna_posnegndsb_v", version=1, holdout=1):

--- a/prediction/src/algorithms/identify/trained_model.py
+++ b/prediction/src/algorithms/identify/trained_model.py
@@ -41,7 +41,6 @@ def predict(dicom_path):
              'z': int,
              'p_nodule': float}
     """
-    
     reader = sitk.ImageSeriesReader()
     filenames = reader.GetGDCMSeriesFileNames(dicom_path)
 


### PR DESCRIPTION
Fixed #191 (Nodule identification doesn't work)

- [fixing the issue](https://github.com/concept-to-clinic/concept-to-clinic/pull/213/commits/43a55868a71ac69833033a561840e1a030718d6a)
- [adding back file name validation](https://github.com/concept-to-clinic/concept-to-clinic/pull/213/commits/807300119c990ac3c5b235f80660367e2df43fa1)

## Description
The problem was - passing image object to `gtr123_model.predict` method, when this method expects a path to a DICOM image.

## How Has This Been Tested?
I checked that it starts with right input, but can't do the full run because of *not enough memory* error. 

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well