### PR TITLE
#203 Fix error showing no module named 'src' found.

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -64,7 +64,7 @@ services:
     build:
       context: .
       dockerfile: ./compose/prediction/Dockerfile-dev
-    command: flask run --host=0.0.0.0 --port=8001
+    command: python -m flask run --host=0.0.0.0 --port=8001
     depends_on:
       - base
     environment:


### PR DESCRIPTION
Closes the issue #203 that threw an error whe you visit the http://localhost:8001/ endpoint in the prediction application.

## Description
Using `python -m flask run ...` to start server. More info in docs [here](http://flask.pocoo.org/docs/0.11/cli/#basic-usage)

## Reference to official issue
This closes issue #203 
### Steps to reproduce
- `docker-compose -f local.yml up`
- visit [http://localhost:8001/](http://localhost:8001)
- Should load the home page

## Motivation and Context
This removes the traceback error when you visit [http://localhost:8001/](http://localhost:8001)

## How Has This Been Tested?
When you visit [http://localhost:8001/](http://localhost:8001) you should not get an error

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well