### PR TITLE
#160 Add Route Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 - docker-compose -v
 - docker -v
 install:
-- pip install flake8 pycodestyle
+- pip install flake8 pycodestyle requests
 before_script:
 - docker-compose -f local.yml build
 script:

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -22,4 +22,4 @@ docker-compose -f local.yml run interface python manage.py test
 docker-compose -f local.yml run interface python manage.py makemigrations --dry-run --check || { echo "ERROR: there were changes in the models, but migration listed above have not been created and are not saved in version control"; exit 1; }
 
 # Start the docker containers and discard the output, otherwise we could hit the Travis log length limit. After 60 seconds test the routes.
-docker-compose -f local.yml up &> /dev/null & sleep 60; python tests/test_routes.py || { echo "ERROR: test_routes.py did not pass. Check above for details."; exit 1; }
+docker-compose -f local.yml up &> /dev/null & python tests/test_routes.py || { echo "ERROR: test_routes.py did not pass. Check above for details."; exit 1; }

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -20,3 +20,6 @@ docker-compose -f local.yml run interface python manage.py test
 
 # return non-zero status code if there are migrations that have not been created
 docker-compose -f local.yml run interface python manage.py makemigrations --dry-run --check || { echo "ERROR: there were changes in the models, but migration listed above have not been created and are not saved in version control"; exit 1; }
+
+# Start the docker containers and discard the output, otherwise we could hit the Travis log length limit. After 60 seconds test the routes.
+docker-compose -f local.yml up &> /dev/null & sleep 60; python tests/test_routes.py || { echo "ERROR: test_routes.py did not pass. Check above for details."; exit 1; }

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,12 +1,15 @@
 import sys
+import time
+
 import requests
 
+TIMEOUT = 180
 LOCALHOST = "http://localhost:{}/"
-SERVICE_PORTS = {"INTERFACE":     {"PORT": 8000, "SITES": ["api"]},
-                 "VUE":           {"PORT": 8080, "SITES": []},
-                 "PREDICTION":    {"PORT": 8001, "SITES": ["classify/predict/",
-                                                           "identify/predict/",
-                                                           "segment/predict/"]},
+SERVICE_PORTS = {"INTERFACE": {"PORT": 8000, "SITES": ["api"]},
+                 "VUE": {"PORT": 8080, "SITES": []},
+                 "PREDICTION": {"PORT": 8001, "SITES": ["classify/predict/",
+                                                        "identify/predict/",
+                                                        "segment/predict/"]},
                  "DOCUMENTATION": {"PORT": 8002, "SITES": []}}
 
 
@@ -23,13 +26,30 @@ def page_errors(url):
 
 if __name__ == '__main__':
     one_failed = False
+    start_time = time.time()
+    services_to_test = list(SERVICE_PORTS.keys())
 
-    for service in SERVICE_PORTS.keys():
-        base_url = LOCALHOST.format(SERVICE_PORTS[service]["PORT"])
-        one_failed |= page_errors(base_url)
-        for site in SERVICE_PORTS[service]["SITES"]:
-            page_errors(base_url + site)
+    while time.time() - start_time < TIMEOUT:
+        for service in services_to_test:
+            try:
+                base_url = LOCALHOST.format(SERVICE_PORTS[service]["PORT"])
+                response = requests.get(base_url)
+            except requests.exceptions.ConnectionError as e:
+                print("{} - not up yet. Continuing with next service...".format(base_url))
+                continue
+            except Exception as e:
+                print("{} - Unexpected exception occurred: {}".format(base_url, e))
+                one_failed = True
 
-    if one_failed:
-        sys.exit(1)
-    sys.exit(0)
+            one_failed |= page_errors(base_url)
+            for site in SERVICE_PORTS[service]["SITES"]:
+                one_failed |= page_errors(base_url + site)
+            services_to_test.remove(service)
+
+        if not services_to_test:
+            sys.exit(1 if one_failed else 0)
+        time.sleep(1)
+
+    closed_ports = [SERVICE_PORTS[service]["PORT"] for service in SERVICE_PORTS.keys()]
+    print("Time limit of {} seconds exceeded. Following ports did not open in time: {}".format(TIMEOUT, closed_ports))
+    sys.exit(1)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,35 @@
+import sys
+import requests
+
+LOCALHOST = "http://localhost:{}/"
+SERVICE_PORTS = {"INTERFACE":     {"PORT": 8000, "SITES": ["api"]},
+                 "VUE":           {"PORT": 8080, "SITES": []},
+                 "PREDICTION":    {"PORT": 8001, "SITES": ["classify/predict/",
+                                                           "identify/predict/",
+                                                           "segment/predict/"]},
+                 "DOCUMENTATION": {"PORT": 8002, "SITES": []}}
+
+
+def page_errors(url):
+    print("Fetching {} ...".format(url))
+    response = requests.get(url)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as http_error:
+        print(http_error)
+        return True
+    return False
+
+
+if __name__ == '__main__':
+    one_failed = False
+
+    for service in SERVICE_PORTS.keys():
+        base_url = LOCALHOST.format(SERVICE_PORTS[service]["PORT"])
+        one_failed |= page_errors(base_url)
+        for site in SERVICE_PORTS[service]["SITES"]:
+            page_errors(base_url + site)
+
+    if one_failed:
+        sys.exit(1)
+    sys.exit(0)


### PR DESCRIPTION
I added a simple Python script that can test whether routes error. It is highly customizable (e.g. one could add to check for the occurrence of the word "error" or "exception" etc.).

## Reference to official issue
This addresses #160 

## Motivation and Context
Currently, the Travis test passes even if some routes are non-functional (like http://0.0.0.0:8001/).

## How Has This Been Tested?
It's currently not passing due to the unfixed issue #203 .
```bash
➜  concept-to-clinic git:(160_route_errors) ✗ bash tests/test_docker.sh
...
+ python tests/test_routes.py
http://localhost:8001/ returns 500
+ echo 'ERROR: test_routes did not pass. Check above for details.'
ERROR: test_routes did not pass. Check above for details.
+ exit 1
```

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well