### PR TITLE
#198: Update case of links in documentation sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ prediction/data/*
 # ignore data
 data/
 docs/apidoc_*/**/*.rst
+!docs/apidoc_*/*_doc.rst

--- a/docs/apidoc_interface/interface_doc.rst
+++ b/docs/apidoc_interface/interface_doc.rst
@@ -1,0 +1,9 @@
+Interface
+=========
+
+.. toctree::
+   :maxdepth: 2
+
+   backend
+   config
+   manage

--- a/docs/apidoc_prediction/prediction_doc.rst
+++ b/docs/apidoc_prediction/prediction_doc.rst
@@ -1,0 +1,7 @@
+Prediction
+==========
+
+.. toctree::
+   :maxdepth: 4
+
+   prediction

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,7 +86,9 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = [
+    '_build', 'Thumbs.db', '.DS_Store', 'apidoc_interface/modules.rst',
+    'apidoc_prediction/modules.rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,8 +33,8 @@ Welcome to Concept to Clinic's documentation!
    :maxdepth: 2
    :caption: Code Documentation
 
-   apidoc_interface/modules
-   apidoc_prediction/modules
+   apidoc_interface/interface_doc
+   apidoc_prediction/prediction_doc
 
 .. toctree::
   :maxdepth: 2


### PR DESCRIPTION

## Description
Create new files to handle the index pages of the `prediction` and `interface` modules inside `docs`.
Generally, `sphinx-api` on these two modules auto generates the documentation. Ignore the previously generated `modules.rst` files because they're automatically generated and changes made to them are overridden.

## Reference to official issue
Fixes issue #198.

## Motivation and Context
Makes the cases of the `Code Documentation` titles begin with upper case.

## How Has This Been Tested?
- `docker-compose -f local.yml build && docker-compose -f local.yml up`
- Open [http://localhost:8002/](http://localhost:8002/)
- Titles in the section *Code Documention* should start with upper case

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well