### PR TITLE
#222 Fix docker-compose build error

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -16,6 +16,7 @@ services:
       context: .
       dockerfile: ./compose/base/Dockerfile-dev
     container_name: base
+    image: concepttoclinic_base
 
   interface:
     build:


### PR DESCRIPTION
This assigns a static name to the generated  `base` image such that docker still works if your directory is named something else than "concept-to-clinic". This addresses #222 .

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well