### PR TITLE
#206 IsADirectoryError fix

### DIFF
--- a/interface/backend/api/views.py
+++ b/interface/backend/api/views.py
@@ -55,7 +55,11 @@ class ImageMetadataApiView(APIView):
             type: string
         '''
         path = request.GET['dicom_location']
-        ds = dicom.read_file(path, force=True)
+        try:
+            ds = dicom.read_file(path, force=True)
+        except IOError as err:
+            print(err)
+            return Response(serializers.DicomMetadataSerializer().data)
         return Response(serializers.DicomMetadataSerializer(ds).data)
 
 

--- a/interface/frontend/build/dev-server.js
+++ b/interface/frontend/build/dev-server.js
@@ -25,7 +25,11 @@ var compiler = webpack(webpackConfig)
 
 var devMiddleware = require('webpack-dev-middleware')(compiler, {
   publicPath: webpackConfig.output.publicPath,
-  quiet: true
+  quiet: true,
+  watchOptions: {
+    aggregateTimeout: 300,
+    poll: 200
+  }
 })
 
 var hotMiddleware = require('webpack-hot-middleware')(compiler, {

--- a/interface/frontend/src/components/annotate-and-segment/NoduleList.vue
+++ b/interface/frontend/src/components/annotate-and-segment/NoduleList.vue
@@ -5,7 +5,7 @@
       <div v-if="nodules.length">
         <div id="accordion" role="tablist" aria-multiselectable="true">
           <template v-for="(nodule, index) in nodules">
-            <nodule :nodule="nodule" :index="index">
+            <nodule :nodule="nodule" :index="index" :key="index">
               <annotate v-if="annotate" :nodule="nodule" :index="index" slot="add-on-editor">
               </annotate>
             </nodule>

--- a/interface/frontend/src/components/detect-and-select/CandidateList.vue
+++ b/interface/frontend/src/components/detect-and-select/CandidateList.vue
@@ -5,7 +5,7 @@
       <template v-if="candidates.length">
         <div id="accordion">
         <template v-for="(candidate, index) in candidates">
-          <candidate :candidate="candidate" :index="index"></candidate>
+          <candidate :candidate="candidate" :index="index" :key="index"></candidate>
         </template>
       </div>
       </template>
@@ -33,7 +33,7 @@ export default {
   },
   methods: {
     fetchCandidates () {
-      this.$axios.get('/api/candidates')
+      this.$axios.get('/api/candidates/')
         .then((response) => {
           this.candidates = response.data
         })

--- a/interface/frontend/src/components/open-image/ImageSeries.vue
+++ b/interface/frontend/src/components/open-image/ImageSeries.vue
@@ -10,7 +10,7 @@
           <div class="card-block">
             <template v-if="availableSeries.length">
               <ul>
-                <li v-for="series in availableSeries">
+                <li v-for="series in availableSeries" :key="series.series_instance_uid">
                   <a href="#" @click="selectSeries(series)">{{ series.series_instance_uid }}</a>
                   <span v-if="series == selected">&larr;</span>
                 </li>

--- a/interface/frontend/src/components/open-image/OpenDICOM.vue
+++ b/interface/frontend/src/components/open-image/OpenDICOM.vue
@@ -9,6 +9,7 @@
   const cornerstone = require('cornerstone-core')
   const cornerstoneTools = require('cornerstone-tools')
   const jquery = require('jquery-slim')
+  const _ = require('lodash')
   cornerstoneTools.external.cornerstone = cornerstone
   cornerstoneTools.external.$ = jquery
 
@@ -58,36 +59,42 @@
       async dicom () {
         let info = await this.info
         info = info.data
-        this.base64data = info.image
-        return {
-          imageId: this.stack.imageIds[this.stack.currentImageIdIndex],
-          slope: info.metadata['Rescale Slope'],
-          rows: info.metadata['Rows'],
-          columns: info.metadata['Columns'],
-          height: info.metadata['Rows'],
-          width: info.metadata['Columns'],
-          columnPixelSpacing: info.metadata['Pixel Spacing']['0'],
-          rowPixelSpacing: info.metadata['Pixel Spacing']['1'],
-          sizeInBytes: info.metadata['Rows'] * info.metadata['Columns'] * 2,
-          minPixelValue: 0,
-          maxPixelValue: 255,
-          intercept: 0,
-          windowCenter: 110,
-          windowWidth: 100,
-          render: cornerstone.renderGrayscaleImage,
-          getPixelData: this.getPixelData,
-          color: false
+        if (!info) return {}
+        else {
+          this.base64data = info.image
+          return {
+            imageId: this.stack.imageIds[this.stack.currentImageIdIndex],
+            slope: info.metadata['Rescale Slope'],
+            rows: info.metadata['Rows'],
+            columns: info.metadata['Columns'],
+            height: info.metadata['Rows'],
+            width: info.metadata['Columns'],
+            columnPixelSpacing: info.metadata['Pixel Spacing']['0'],
+            rowPixelSpacing: info.metadata['Pixel Spacing']['1'],
+            sizeInBytes: info.metadata['Rows'] * info.metadata['Columns'] * 2,
+            minPixelValue: 0,
+            maxPixelValue: 255,
+            intercept: 0,
+            windowCenter: 110,
+            windowWidth: 100,
+            render: cornerstone.renderGrayscaleImage,
+            getPixelData: this.getPixelData,
+            color: false
+          }
         }
       },
       async display () {
         const element = this.$refs.DICOM
         const dicom = await this.dicom
-        cornerstone.registerImageLoader(this.view.type, () => {
-          return new Promise((resolve) => { resolve(dicom) })
-        })
-        const image = await cornerstone.loadImage(dicom.imageId)
-        cornerstone.displayImage(element, image)
-        return image
+        if (_.isEmpty(dicom)) return ''
+        else {
+          cornerstone.registerImageLoader(this.view.type, () => {
+            return new Promise((resolve) => { resolve(dicom) })
+          })
+          const image = await cornerstone.loadImage(dicom.imageId)
+          cornerstone.displayImage(element, image)
+          return image
+        }
       }
     },
     methods: {

--- a/interface/frontend/src/components/open-image/TreeView.vue
+++ b/interface/frontend/src/components/open-image/TreeView.vue
@@ -17,7 +17,7 @@
                    :key="child.name"
                    :model="child"
         ></tree-view>
-        <li @click="select()" v-for="file in model.files" class="text-muted">{{ file.name }}</li>
+        <li @click="select()" v-for="file in model.files" class="text-muted" :key="file.name">{{ file.name }}</li>
       </ul>
     </li>
   </ul>

--- a/interface/frontend/src/components/report-and-export/RSNAStandardTemplate.vue
+++ b/interface/frontend/src/components/report-and-export/RSNAStandardTemplate.vue
@@ -63,7 +63,7 @@
       </p>
 
       <div class="nodule-list" v-else>
-        <nodule v-for="(nodule, index) in findings.lungNodules" :nodule="nodule" :index="index">
+        <nodule v-for="(nodule, index) in findings.lungNodules" :nodule="nodule" :index="index" :key="index">
           <div class="nodule-info-container" slot="add-on-editor">
             <!-- {{ nodule }} -->
             <div class="nodule-info">


### PR DESCRIPTION
Loading [http://localhost:8080/](http://localhost:8080) throws an `IsADirectoryError: [Errno 21] Is a directory: '/'`

## Description
The endpoint is called every time the front end loads. Since the `dicom.readfile()` method is an IO op, I do a `try/except` to catch the `IOError` 21. As it is, this error is only anticipated on page load because there's no default path to a dicom file. I return an 'empty' response back so that the error is handled on the server-side and presents the client side an opportunity to handle it too.

### To handle the empty response from the server.

`Cornerstone` throws errors if handed empty fields on the front end. Since the functions trigger calls to the server endpoint on load (I am assuming this is because of the `async/await` computed functions -- please correct my reasoning here if I'm wrong) and has nothing to display, catering for instances of empty values mitigates these unnecessary errors. Check the changes in [OpenDICOM.vue file](https://github.com/musale/concept-to-clinic/blob/fb39d63d387f2706c6e69792c3739bf61f76506f/interface/frontend/src/components/open-image/OpenDICOM.vue).

## Reference to official issue
Fixes issue #206 

## Motivation and Context
This change removes the error logs for `IsADirectoryError` and also handles instances where a dicom file is not found.

## How Has This Been Tested?
- Load [http://localhost:8080/](http://localhost:8080)
- There should be no error traceback

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well