### PR TITLE
Fixed interface API to return relative urls instead of absoulte

### DIFF
--- a/interface/backend/api/tests.py
+++ b/interface/backend/api/tests.py
@@ -4,20 +4,12 @@ from backend.cases.factories import (
     CandidateFactory,
     NoduleFactory
 )
-from django.test import (
-    RequestFactory,
-    TestCase
-)
+from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APIRequestFactory
 
 
 class ViewTest(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.rest_factory = APIRequestFactory()
-
     def test_nodule_list_viewset(self):
         # first try an endpoint without a nodule
         url = reverse('nodule-list')
@@ -28,8 +20,7 @@ class ViewTest(TestCase):
         # now create a nodule and figure out what we expect to see in the list
         case = CaseFactory()
         nodules = NoduleFactory.create_batch(size=3, case=case)
-        request = self.factory.get(url)
-        serialized = [NoduleSerializer(n, context={'request': request}) for n in nodules]
+        serialized = [NoduleSerializer(n, context={'request': None}) for n in nodules]
         expected = [s.data for s in serialized]
 
         # check the actual response

--- a/interface/backend/api/views.py
+++ b/interface/backend/api/views.py
@@ -22,22 +22,32 @@ from rest_framework.views import APIView
 from ..cases import enums
 
 
-class CaseViewSet(viewsets.ModelViewSet):
+class ViewSetBase(viewsets.ModelViewSet):
+    def get_serializer_context(self):
+        context = super(ViewSetBase, self).get_serializer_context()
+
+        # getting rid of absulute URLs
+        context.update({'request': None})
+
+        return context
+
+
+class CaseViewSet(ViewSetBase):
     queryset = Case.objects.all()
     serializer_class = serializers.CaseSerializer
 
 
-class CandidateViewSet(viewsets.ModelViewSet):
+class CandidateViewSet(ViewSetBase):
     queryset = Candidate.objects.all()
     serializer_class = serializers.CandidateSerializer
 
 
-class NoduleViewSet(viewsets.ModelViewSet):
+class NoduleViewSet(ViewSetBase):
     queryset = Nodule.objects.all()
     serializer_class = serializers.NoduleSerializer
 
 
-class ImageSeriesViewSet(viewsets.ModelViewSet):
+class ImageSeriesViewSet(ViewSetBase):
     queryset = ImageSeries.objects.all()
     serializer_class = serializers.ImageSeriesSerializer
 


### PR DESCRIPTION
Now each `[Model]ViewSet` will inherit from `ViewSetBase` and that base view class has `get_serializer_context` method overridden to set `'request': None` for the serialization context.

## Description
After this change serialized entities have relative URLs instead of absolute and it makes them usable from the Vue.js application. Problem with absolute URLs - interface API is hosted on different port number then *Vue.js* and requests to that port number being blocked by browser because of CORS policy. Now the URLs are pointing to the same host and will be redirected by *Node.js* server.

Fix suggested by @isms when discussing #228

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well