### PR TITLE
fixed Vue.js compilation error by updating Vue.js version

### DIFF
--- a/interface/frontend/package.json
+++ b/interface/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "vue-resource": "^1.3.4",
-    "vue": "^2.4.2"
+    "vue": "^2.5.6"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.2",
@@ -82,7 +82,7 @@
     "vue-loader": "^13.0.4",
     "vue-router": "^2.7.0",
     "vue-style-loader": "^3.0.1",
-    "vue-template-compiler": "^2.4.2",
+    "vue-template-compiler": "^2.5.6",
     "cornerstone-core": " 0.13.0",
     "cornerstone-tools": " 0.10.0",
     "jquery-slim": "^3.0.0",


### PR DESCRIPTION
Because of [this bug](https://github.com/vuejs/vue/issues/7084) in version 2.4.2 of **Vue.js** the compilation of Vue app was broken. I have fixed it by updating the package.


## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well