### PR TITLE
Implemented Imagery selection screen

### DIFF
--- a/interface/backend/api/urls.py
+++ b/interface/backend/api/urls.py
@@ -8,7 +8,8 @@ from backend.api.views import (
     candidate_mark,
     candidate_dismiss,
     case_report,
-    nodule_update
+    nodule_update,
+    start_new_case
 )
 from django.conf.urls import (
     include,
@@ -31,6 +32,8 @@ urlpatterns = [
     url(r'^candidates/(?P<candidate_id>\d+)/dismiss$', candidate_dismiss, name='candidate-dismiss'),
     url(r'^candidates/(?P<candidate_id>\d+)/mark$', candidate_mark, name='candidate-mark'),
     url(r'^nodules/(?P<nodule_id>\d+)/update$', nodule_update, name='nodule-update'),
+    url(r'^cases/start_new_case$', start_new_case, name='start-new-case'),
+
 ]
 
 # Support different suffixes

--- a/interface/frontend/package.json
+++ b/interface/frontend/package.json
@@ -70,6 +70,7 @@
     "opn": "^5.1.0",
     "optimize-css-assets-webpack-plugin": "^2.0.0",
     "ora": "^1.2.0",
+    "path-dirname": "^1.0.2",
     "phantomjs-prebuilt": "^2.1.14",
     "rimraf": "^2.6.0",
     "sass-loader": "^6.0.6",


### PR DESCRIPTION
## Description
According to [documentation](http://concept-to-clinic.readthedocs.io/en/latest/design-doc.html#imagery-interface-frontend) on this screen should in particular:

- List available DICOM images on local filesystem.
- Display a preview of an available DICOM image.
- Allow user to select a given image and **start a new “Case.”** This image will be used in the identification step next.

All these features has been implemented in this PR(frontend and backend).
- Now user can see details about currently running case
- Can see list of directories and preview an image
- Can start a new case for selected image

![start a new case](http://g.recordit.co/Htja5hXlvc.gif)

## Reference to official issue
Related to #145 and #202


## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well