### PR TITLE
#195 Stop slow tests after set period of time

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -74,6 +74,7 @@ services:
       - LC_ALL=C.UTF-8
       - LANG=C.UTF-8
       - RUN_SLOW_TESTS=false
+      - TESTS_TIMEOUT=1
     volumes:
       - ./prediction/:/app:cached
       - ./tests/assets/test_image_data/small:/images:cached

--- a/prediction/src/algorithms/segment/assets/lung-mask.npy
+++ b/prediction/src/algorithms/segment/assets/lung-mask.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:54c38f78e791dc7cbe7ffcaab19dce18346ede67e41a4bb7edcd397e0eeb34db
+oid sha256:427aa2da345ef4f210a9824532eaa89a81dc47b670e39941a4f1cde52abe0a5a
 size 8388688

--- a/prediction/src/tests/__init__.py
+++ b/prediction/src/tests/__init__.py
@@ -1,6 +1,5 @@
 import sys
 import os
-import pytest
 import torch  # noqa # pylint: disable=unused-import
 
 sys.path.append(os.path.join(os.path.dirname(__file__),
@@ -8,12 +7,16 @@ sys.path.append(os.path.join(os.path.dirname(__file__),
                              os.path.pardir))
 
 
-def skip_slow_test():
+def get_timeout():
     """
-    Skip the wrapped test function unless the environment variable RUN_SLOW_TESTS is set.
+    If RUN_SLOW_TESTS is set to True, all tests should be run. Thus, no timeout is desired and this returns 0.
+    Otherwise the content of TESTS_TIMEOUT is returned.
+    :return: Time limit after which certain tests should be stopped
     """
-    value = os.environ.get('RUN_SLOW_TESTS', '')
-    return value.lower() not in {'1', 'true'}
-
-
-skip_if_slow = pytest.mark.skipif(skip_slow_test(), reason='Takes very long')
+    DEFAULT_TIMEOUT = 15
+    run_slow_tests_variable = os.environ.get('RUN_SLOW_TESTS', '')
+    run_slow_tests = (run_slow_tests_variable.lower() in {'1', 'true'})
+    if run_slow_tests:
+        return 0
+    else:
+        return int(os.environ.get('TESTS_TIMEOUT', DEFAULT_TIMEOUT))

--- a/prediction/src/tests/test_endpoints.py
+++ b/prediction/src/tests/test_endpoints.py
@@ -14,8 +14,6 @@ from flask import url_for
 from src.algorithms import classify, identify, segment
 from src.factory import create_app
 
-from . import skip_if_slow
-
 
 def get_data(response):
     data = response.get_data(as_text=True)
@@ -61,7 +59,7 @@ def test_endpoint_documentation(client):
         assert data['description'] == docstrings[algorithm]
 
 
-@skip_if_slow
+@pytest.mark.stop_timeout
 def test_identify(client, dicom_path, content_type):
     url = client.url_for('predict', algorithm='identify')
     test_data = {'dicom_path': dicom_path}

--- a/prediction/src/tests/test_identification.py
+++ b/prediction/src/tests/test_identification.py
@@ -1,10 +1,10 @@
 import numpy as np
+import pytest
 
-from . import skip_if_slow
 from ..algorithms.identify import trained_model
 
 
-@skip_if_slow
+@pytest.mark.stop_timeout
 def test_identify_nodules_001(dicom_path, nodule_001):
     predicted = trained_model.predict(dicom_path)
     first = predicted[0]
@@ -12,7 +12,7 @@ def test_identify_nodules_001(dicom_path, nodule_001):
     assert (dist < 10)
 
 
-@skip_if_slow
+@pytest.mark.stop_timeout
 def test_identify_nodules_003(dicom_path_003, nodule_003):
     predicted = trained_model.predict(dicom_path_003)
     first = predicted[0]

--- a/prediction/src/tests/test_segmentation.py
+++ b/prediction/src/tests/test_segmentation.py
@@ -1,10 +1,12 @@
 import os
+import time
 
 import pylidc as pl
+import pytest
 
 from config import Config
 
-from . import skip_if_slow
+from . import get_timeout
 from ..algorithms.identify.prediction import load_patient_images
 from ..algorithms.segment.trained_model import predict
 from ..preprocess.lung_segmentation import save_lung_segments, get_z_range
@@ -33,7 +35,7 @@ def test_nodule_segmentation(dicom_path, nodule_001):
     predict(dicom_path, [nodule_001])
 
 
-@skip_if_slow
+@pytest.mark.stop_timeout
 def test_lung_segmentation(dicom_paths):
     """Test whether the annotations of the LIDC images are inside the segmented lung masks.
     Iterate over all local LIDC images, fetch the annotations, compute their positions within the masks and check that
@@ -56,3 +58,11 @@ def test_lung_segmentation(dicom_paths):
             z_mask = int(abs(min_z) - abs(centroid_z))
             mask_value = patient_mask[z_mask, x_mask, y_mask]
             assert mask_value == 255
+
+
+@pytest.mark.stop_timeout
+def test_stop_timeout():
+    timeout = get_timeout()
+    if timeout > 0:
+        time.sleep(timeout + 1)
+        raise ValueError("This test should timeout")

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -7,7 +7,7 @@
 set -ex
 
 # run the model service's tests
-docker-compose -f local.yml run prediction pytest -rs
+docker-compose -f local.yml run prediction pytest -rsx
 
 # run the backend API tests
 docker-compose -f local.yml run interface python manage.py test


### PR DESCRIPTION
We don't want to completely skip slow tests since this can hide bugs (e.g. #191). Instead, we want to start the slow tests but skip them after a specified period of time.

## Description
If the environment variable RUN_SLOW_TESTS is set to True, all tests should be run. Otherwise tests that exceed the time specified by the variable TESTS_TIMEOUT (default is 15 seconds) are skipped without causing an error.

## Reference to official issue
This addresses #195 

## Motivation and Context
It was necessary to create a new [hook](https://github.com/concept-to-clinic/concept-to-clinic/compare/master...WGierke:195_stop_slow_tests?expand=1#diff-507495becfd1e874bad6e0b1cf4437b2R115) that checks whether a test should timeout, that kills the test when exceeding the timeout and then returns that the test is not failing (if the timeout is the only reason for the test exit). It wasn't possible to just use pytest-timeout and the xfail marker since pytest-timeout does not raise an exception when killing a test which could be caught by the xfail marker.

## How Has This Been Tested?
I added a [test](https://github.com/concept-to-clinic/concept-to-clinic/compare/master...WGierke:195_stop_slow_tests?expand=1#diff-ed63136572f32bc5f7500b864f9bdfa9R60) that should always timeout (if we want slow tests to timeout), otherwise it raises an uncaught exception. The tests that are failing are expected to fail (as stated in the issue and #229 ) namely 
`src/tests/test_endpoints.py::test_identify`, `src/tests/test_identification.py::test_identify_nodules_001` and `src/tests/test_identification.py::test_identify_nodules_003`.

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
