### PR TITLE
Detect and select: attaching nodule centroid marker to current slice

### DIFF
--- a/interface/backend/api/serializers.py
+++ b/interface/backend/api/serializers.py
@@ -48,6 +48,7 @@ class CandidateSerializer(serializers.HyperlinkedModelSerializer):
         read_only_fields = ('created',)
 
     centroid = ImageLocationSerializer()
+    case = CaseSerializer()
 
     def create(self, validated_data):
         case_data = validated_data.pop('case')

--- a/interface/backend/api/urls.py
+++ b/interface/backend/api/urls.py
@@ -9,7 +9,8 @@ from backend.api.views import (
     candidate_dismiss,
     case_report,
     nodule_update,
-    update_candidate_location
+    update_candidate_location,
+    candidates_info
 )
 from django.conf.urls import (
     include,
@@ -29,6 +30,7 @@ urlpatterns = [
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^images/available$', ImageAvailableApiView.as_view(), name='images-available'),
     url(r'^images/metadata$', ImageMetadataApiView.as_view(), name='images-metadata'),
+    url(r'^candidates-info$', candidates_info, name='candidates-info'),
     url(r'^candidates/(?P<candidate_id>\d+)/dismiss$', candidate_dismiss, name='candidate-dismiss'),
     url(r'^candidates/(?P<candidate_id>\d+)/mark$', candidate_mark, name='candidate-mark'),
     url(r'^candidates/(?P<candidate_id>\d+)/move$', update_candidate_location, name='update-candidate-location'),

--- a/interface/frontend/src/components/detect-and-select/Candidate.vue
+++ b/interface/frontend/src/components/detect-and-select/Candidate.vue
@@ -25,11 +25,15 @@
         </tr>
         <tr>
           <td>X:</td>
-          <td>{{ candidate.centroid.x }}</td>
+          <td><b>{{ candidate.centroid.x }}</b></td>
         </tr>
         <tr>
           <td>Y:</td>
-          <td>{{ candidate.centroid.y }}</td>
+          <td><b>{{ candidate.centroid.y }}</b></td>
+        </tr>
+        <tr>
+          <td class="pr-3">Slice index: </td>
+          <td><b>{{ candidate.centroid.z }}</b></td>
         </tr>
       </tbody>
     </table>

--- a/interface/frontend/src/components/open-image/NoduleMarker.vue
+++ b/interface/frontend/src/components/open-image/NoduleMarker.vue
@@ -1,6 +1,6 @@
 <template>
-  <vue-draggable-resizable class="nodule-marker" v-if="scaledMarker"
-                           :x="scaledMarker.x" :y="scaledMarker.y"
+  <vue-draggable-resizable class="nodule-marker" :class="{ overlapped: markerOverlappedBySlice }"
+                           v-if="scaledMarker" :x="scaledMarker.x" :y="scaledMarker.y"
                            :w="markerImageSize" :h="markerImageSize"
                            :minw="markerImageSize" :minh="markerImageSize"
                            :resizable="false" v-on:dragstop="onDragFinished">
@@ -10,12 +10,20 @@
 <script>
   import Vue from 'vue'
   import VueDraggableResizable from 'vue-draggable-resizable'
-  import { EventBus } from '../../main.js'
+  import {EventBus} from '../../main.js'
 
   export default {
     components: {VueDraggableResizable},
     name: 'open-dicom',
-    props: ['zoomRate', 'offsetX', 'offsetY', 'marker'],
+    props: {
+      zoomRate: null,
+      offsetX: null,
+      offsetY: null,
+      marker: null,
+      sliceIndex: {
+        type: Number
+      }
+    },
     data () {
       const markerImageSize = 32
       return {
@@ -56,6 +64,10 @@
         scaledInfo.y = scaledInfo.y * this.zoomRate - this.offsetY - this.markerImageSize / 2
 
         return scaledInfo
+      },
+      markerOverlappedBySlice () {
+        const val = this.scaledMarker.z !== this.sliceIndex
+        return val
       }
     },
     methods: {
@@ -63,16 +75,26 @@
         var scaledX = x / this.zoomRate + this.offsetX + this.markerImageSize / 2
         var scaledY = y / this.zoomRate + this.offsetY + this.markerImageSize / 2
 
-        EventBus.$emit('nodule-marker-moved', scaledX, scaledY, this.marker.z)
+        EventBus.$emit('nodule-marker-moved', scaledX, scaledY, this.sliceIndex)
       }
     }
   }
 </script>
 
 <style lang="scss" scoped>
+  @keyframes opacity-pulse {
+    0% { opacity: 0.3; }
+    50% { opacity: 0.9; }
+    100% { opacity: 0.3; }
+  }
+
   .DICOM-container {
     .nodule-marker {
       background-image: url('../../assets/images/nodule-marker.png');
+
+      &.overlapped {
+        animation: opacity-pulse 1s infinite ease-in-out;
+      }
     }
   }
 </style>


### PR DESCRIPTION
Implemented slice switching for candidate list, and a way for user to see when slice differs and attach the marker to current slice.

## Description
Following features has been implemented:
- switching the viewer to candidate's slice when selecting a candidate
- showing to user that marker is on an other slice
- clicking on a marker attaches it to current slice

On back-end I have added a method for loading candidates with cases and series. Series object will also have list of DICOM files in the folder saved in `uri` property.

## Reference to official issue
It's an improvement of #148

## Screenshot:
![detect-and-select-z](http://g.recordit.co/6AwCrut5WW.gif)
[full size image](http://g.recordit.co/6AwCrut5WW.gif)

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
