### PR TITLE
#229 Fix identification on LUNA

### DIFF
--- a/prediction/src/algorithms/identify/trained_model.py
+++ b/prediction/src/algorithms/identify/trained_model.py
@@ -42,11 +42,15 @@ def predict(dicom_path):
              'p_nodule': float}
     """
     reader = sitk.ImageSeriesReader()
-    filenames = reader.GetGDCMSeriesFileNames(dicom_path)
-
-    if not filenames:
-        message = "The path {} doesn't contain any .mhd or .dcm files"
-        raise ValueError(message.format(dicom_path))
+    if dicom_path.endswith('.mhd'):
+        if not path.isfile(dicom_path):
+            message = "The path {} does not exist"
+            raise ValueError(message.format(dicom_path))
+    else:
+        filenames = reader.GetGDCMSeriesFileNames(dicom_path)
+        if not filenames:
+            message = "The path {} doesn't contain any .mhd or .dcm files"
+            raise ValueError(message.format(dicom_path))
 
     # all required preprocssing and prediction is implemented in gtr123_model
     result = gtr123_model.predict(dicom_path)

--- a/prediction/src/tests/test_identification.py
+++ b/prediction/src/tests/test_identification.py
@@ -18,3 +18,11 @@ def test_identify_nodules_003(dicom_path_003, nodule_003):
     first = predicted[0]
     dist = np.sqrt(np.sum([(first[s] - nodule_003[s]) ** 2 for s in ["x", "y", "z"]]))
     assert (dist < 10)
+
+
+@pytest.mark.stop_timeout
+def test_identify_luna(metaimage_path, luna_nodule):
+    predicted = trained_model.predict(metaimage_path)
+    first = predicted[0]
+    dist = np.sqrt(np.sum([(first[s] - luna_nodule[s]) ** 2 for s in ["x", "y", "z"]]))
+    assert (dist < 10)


### PR DESCRIPTION
I fixed the identification of LUNA nodules as far as it gets on my machine. This means that currently all tests in `src/tests/test_identification.py` are failing for me since I don't have 21 GB of RAM (if RUN_SLOW_TESTS is set to true). Maybe someone else can execute them and send me tracebacks for further error investigation?

## Description
The problem was that sometimes the direct path to a MHD file was handed to the function instead of the path to the directory. The made changes should support now both alternatives.

## Reference to official issue
This addresses #229 - identification test(s) should pass for luna scans.

## How Has This Been Tested?
I added the test given in #229 .

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
