### PR TITLE
#244 Update the version number in the navbar

### DIFF
--- a/interface/frontend/build/dev-server.js
+++ b/interface/frontend/build/dev-server.js
@@ -5,6 +5,10 @@ if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = JSON.parse(config.dev.env.NODE_ENV)
 }
 
+if (!process.env.GIT_HASH_VERSION) {
+  process.env.GIT_HASH_VERSION = JSON.parse(config.dev.env.GIT_HASH_VERSION)
+}
+
 var opn = require('opn')
 var path = require('path')
 var express = require('express')

--- a/interface/frontend/config/dev.env.js
+++ b/interface/frontend/config/dev.env.js
@@ -1,6 +1,9 @@
 var merge = require('webpack-merge')
+var shell = require('shelljs')
 var prodEnv = require('./prod.env')
+var hash = shell.cat('HEAD').exec('cut -d " " -f2', {silent: true}).stdout
 
 module.exports = merge(prodEnv, {
-  NODE_ENV: '"development"'
+  NODE_ENV: '"development"',
+  GIT_HASH_VERSION: JSON.stringify(hash.slice(0, 9))
 })

--- a/interface/frontend/src/components/AppNav.vue
+++ b/interface/frontend/src/components/AppNav.vue
@@ -28,7 +28,7 @@
 export default {
   data () {
     return {
-      appVersion: 'a0b1c2d'
+      appVersion: process.env.GIT_HASH_VERSION || 'Git hash not found'
     }
   }
 }

--- a/local.yml
+++ b/local.yml
@@ -55,7 +55,7 @@ services:
       - ./interface/frontend/dist:/app/dist:cached
       - ./interface/frontend/static:/app/static:cached
       - ./interface/frontend/test:/app/test:cached
-      - ./.git/logs/HEAD:/HEAD:cached
+      - ./.git/logs/HEAD:/app/HEAD:cached
     links:
       - interface
     ports:


### PR DESCRIPTION
Updates the short git hash that matches the current version of the code in the navbar

## Description
This allows the navbar to have the short version of the current commit hash from HEAD.

## Reference to official issue
Fixes issue #244 

## Motivation and Context
Get the hash of the latest commit as the display instead of a static value.

## How Has This Been Tested?
- Run `docker-compose -f local.yml build`
- Run `docker-compose -f local.yml up`
- View the application UI on [http://localhost:8080/#/](http://localhost:8080/#/)
- Open another terminal in the root of your project repo and run `git rev-parse --short HEAD`
- The hash on the top right side of the navbar should be the same to the value of the previous step

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
