### PR TITLE
#229 Fix Classification

### DIFF
--- a/interface/backend/api/views.py
+++ b/interface/backend/api/views.py
@@ -16,12 +16,10 @@ from backend.images.models import ImageSeries
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 from django.shortcuts import get_object_or_404
-from rest_framework import viewsets, status
+from rest_framework import viewsets
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
-from ..cases import enums
 
 
 class ViewSetBase(viewsets.ModelViewSet):

--- a/interface/backend/cases/tests.py
+++ b/interface/backend/cases/tests.py
@@ -1,5 +1,3 @@
-import json
-
 from backend.cases.factories import (
     CandidateFactory,
     CaseFactory,

--- a/prediction/src/preprocess/load_ct.py
+++ b/prediction/src/preprocess/load_ct.py
@@ -147,6 +147,9 @@ class MetaData:
         # the default axes order which is used is: (z, y, x)
         return self.meta.GetOrigin()[::-1]
 
+    def extract_origin_dicom(self):
+        return [0] * 3
+
     def non_copy_constructor(self, meta_instance):
         self.meta = meta_instance.meta
         self.spacing = meta_instance.spacing
@@ -167,6 +170,7 @@ class MetaData:
         if dicom_meta:
             # list of methods for DICOM meta
             self.spacing = self.extract_spacing_dcm()
+            self.origin = self.extract_origin_dicom()
         elif mhd_meta:
             # list of methods for MetaImage meta
             self.spacing = self.extract_spacing_mhd()

--- a/prediction/src/tests/test_classification.py
+++ b/prediction/src/tests/test_classification.py
@@ -5,7 +5,13 @@ def test_classify_predict_load(metaimage_path, model_path):
     assert not trained_model.predict(metaimage_path, [], model_path)
 
 
-def test_classify_predict_inference(metaimage_path, luna_nodule, model_path):
+def test_classify_dicom(dicom_paths, nodule_locations, model_path):
+    predicted = trained_model.predict(dicom_paths[0], nodule_locations, model_path)
+    assert predicted
+    assert 0 <= predicted[0]['p_concerning'] <= 1
+
+
+def test_classify_luna(metaimage_path, luna_nodule, model_path):
     predicted = trained_model.predict(metaimage_path, [luna_nodule], model_path)
     assert predicted
     assert 0 <= predicted[0]['p_concerning'] <= 1


### PR DESCRIPTION
There was no method implemented how to get the origin of a DICOM image series which resulted in an error. I initially set it to [0, 0, 0] but due to my lack of domain knowledge I don't know how to correctly calculate it from DICOM images. If you know the answer, feel free to comment :)

## Reference to official issue
This references #229 - classification doesn't work on DICOM images.

## How Has This Been Tested?
I added the test given in #229 

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
