### PR TITLE
Move all serializers into a single file in the same dir

### DIFF
--- a/interface/backend/api/views.py
+++ b/interface/backend/api/views.py
@@ -5,11 +5,11 @@ import glob
 
 import dicom
 from backend.api import serializers
+from backend.cases.serializers import CaseSerializer
 from backend.cases.models import (
     Case,
     Candidate,
-    Nodule,
-    CaseSerializer
+    Nodule
 )
 
 from backend.images.models import ImageSeries

--- a/interface/backend/cases/models.py
+++ b/interface/backend/cases/models.py
@@ -1,11 +1,9 @@
-from backend.images.models import ImageSeriesSerializer, ImageLocationSerializer
 from django.core.validators import (
     MaxValueValidator,
     MinValueValidator
 )
 from django.db import models
 from django.utils import timezone
-from rest_framework import serializers
 
 from . import enums
 
@@ -191,30 +189,3 @@ class NoduleFeatures(models.Model):
     appearance_feature = models.IntegerField(choices=enums.format_enum(enums.AppearanceFeature))
     diameter = models.DecimalField(max_digits=5, decimal_places=2)
     density_feature = models.IntegerField(choices=enums.format_enum(enums.DensityFeature))
-
-
-class CandidateSerializer(serializers.ModelSerializer):
-    centroid = ImageLocationSerializer(read_only=True)
-
-    class Meta:
-        model = Candidate
-        fields = ('id', 'created', 'centroid', 'case_id', 'probability_concerning')
-
-
-class NoduleSerializer(serializers.ModelSerializer):
-    candidates = CandidateSerializer(read_only=True, many=True)
-    centroid = ImageLocationSerializer(read_only=True)
-
-    class Meta:
-        model = Case
-        fields = ('id', 'created', 'candidates', 'centroid')
-
-
-class CaseSerializer(serializers.ModelSerializer):
-    series = ImageSeriesSerializer()
-    candidates = CandidateSerializer(read_only=True, many=True)
-    nodules = NoduleSerializer(read_only=True, many=True)
-
-    class Meta:
-        model = Case
-        fields = ('id', 'created', 'series', 'candidates', 'nodules')

--- a/interface/backend/cases/serializers.py
+++ b/interface/backend/cases/serializers.py
@@ -1,0 +1,35 @@
+from rest_framework import serializers
+from backend.images.serializers import (
+    ImageSeriesSerializer, ImageLocationSerializer
+)
+from .models import (
+    Candidate, Case
+)
+
+
+class CandidateSerializer(serializers.ModelSerializer):
+    centroid = ImageLocationSerializer(read_only=True)
+
+    class Meta:
+        model = Candidate
+        fields = ('id', 'created', 'centroid',
+                  'case_id', 'probability_concerning')
+
+
+class NoduleSerializer(serializers.ModelSerializer):
+    candidates = CandidateSerializer(read_only=True, many=True)
+    centroid = ImageLocationSerializer(read_only=True)
+
+    class Meta:
+        model = Case
+        fields = ('id', 'created', 'candidates', 'centroid')
+
+
+class CaseSerializer(serializers.ModelSerializer):
+    series = ImageSeriesSerializer()
+    candidates = CandidateSerializer(read_only=True, many=True)
+    nodules = NoduleSerializer(read_only=True, many=True)
+
+    class Meta:
+        model = Case
+        fields = ('id', 'created', 'series', 'candidates', 'nodules')

--- a/interface/backend/images/models.py
+++ b/interface/backend/images/models.py
@@ -3,7 +3,6 @@ import glob
 import dicom
 from django.db import models
 from django.utils._os import safe_join
-from rest_framework import serializers
 
 
 class ImageSeries(models.Model):
@@ -38,12 +37,6 @@ class ImageSeries(models.Model):
             uri=uri)
 
 
-class ImageSeriesSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = ImageSeries
-        fields = ('id', 'patient_id', 'series_instance_uid', 'uri')
-
-
 class ImageLocation(models.Model):
     """
     Model representing a certain voxel location on certain image
@@ -55,11 +48,3 @@ class ImageLocation(models.Model):
     y = models.PositiveSmallIntegerField(help_text='Voxel index for Y axis, zero-index, from top left')
 
     z = models.PositiveSmallIntegerField(help_text='Slice index for Z axis, zero-index')
-
-
-class ImageLocationSerializer(serializers.ModelSerializer):
-    series = ImageSeriesSerializer()
-
-    class Meta:
-        model = ImageLocation
-        fields = ('id', 'series', 'x', 'y', 'z')

--- a/interface/backend/images/serializers.py
+++ b/interface/backend/images/serializers.py
@@ -1,0 +1,18 @@
+from rest_framework import serializers
+from .models import (
+    ImageSeries, ImageLocation
+)
+
+
+class ImageSeriesSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ImageSeries
+        fields = ('id', 'patient_id', 'series_instance_uid', 'uri')
+
+
+class ImageLocationSerializer(serializers.ModelSerializer):
+    series = ImageSeriesSerializer()
+
+    class Meta:
+        model = ImageLocation
+        fields = ('id', 'series', 'x', 'y', 'z')


### PR DESCRIPTION
## Description
Move serializers in the `interface` app into a single file for each directory

## Reference to official issue
Addresses issue #201 

## Motivation and Context
Makes the app structure cleaner and concise


## How Has This Been Tested?
`interface.backend.cases` and `interface.backend.images` have a `serializers.py` file that holds all the respective serializers previously situated in their `models.py` files.

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
