### PR TITLE
Updated documentation pages to the docs TOC

### DIFF
--- a/docs/algorithms/algorithm_DL_Munich.md
+++ b/docs/algorithms/algorithm_DL_Munich.md
@@ -11,20 +11,31 @@ The 7th place at the Data Science Bowl 2017 on the private leaderboard.
 
 ## Prerequisites
 
-| Dependency |   Name   | Version  |
-|------------|----------|----------|
-| Language   | Python   | 3.4.3    | 
-| ML engine  |          |          | 
-| ML backend | Tensorflow | 1.0.1  | 
-| OS         | Ubuntu   | 14.04    | 
-| Processor  | CPU      | Intel(R) Core(TM) i7-4930K CPU |
-|            | GPU      | Nvidia GTX 1080 |
-| GPU driver | CUDA     | 8.0      |
-|            | cuDNN    | 5.1      |
-
+```eval_rst
++------------+------------+--------------------------------+
+| Dependency |   Name     | Version                        |
++============+============+================================+
+| Language   | Python     | 3.4.3                          |
++------------+------------+--------------------------------+
+| ML engine  |            |                                |
++------------+------------+--------------------------------+
+| ML backend | Tensorflow | 1.0.1                          |
++------------+------------+--------------------------------+
+| OS         | Ubuntu     | 14.04                          |
++------------+------------+--------------------------------+
+| Processor  | CPU        | Intel(R) Core(TM) i7-4930K CPU |
++------------+------------+--------------------------------+
+|            | GPU        | Nvidia GTX 1080                |
++------------+------------+--------------------------------+
+| GPU driver | CUDA       | 8.0                            |
++------------+------------+--------------------------------+
+|            | cuDNN      | 5.1                            |
++------------+------------+--------------------------------+
+```
 
 **Dependency packages:**
-```
+
+```python
 opencv-python==3.2.0.6
 Python 3.4.3
 dicom==0.9.9-1
@@ -88,12 +99,19 @@ The resulting cluster centers are used to crop candidates from the original data
 ### Final Ensemble
 For the final solution four different Patient-Classifier-Networks have been employed, the outputs of which were averaged to a single prediction. 
 
-| Network | isotropic scan resolution | architecture | 
-|-------------|-----|---------------------|
-| 05res 3DNet | 0.5 | 3D residual network |
-| 07res 3DNet | 0.7 | 3D residual network |
-| 05res 2DNet | 0.5 | 2D residual network |
-| 07res 2DNet | 0.7 | 2D residual network |
+```eval_rst
++-------------+---------------------------+---------------------+
+| Network     | isotropic scan resolution | architecture        |
++=============+===========================+=====================+
+| 05res 3DNet | 0.5                       | 3D residual network |
++-------------+---------------------------+---------------------+
+| 07res 3DNet | 0.7                       | 3D residual network |
++-------------+---------------------------+---------------------+
+| 05res 2DNet | 0.5                       | 2D residual network |
++-------------+---------------------------+---------------------+
+| 07res 2DNet | 0.7                       | 2D residual network |
++-------------+---------------------------+---------------------+
+```
 
 ## Trained model
 
@@ -107,12 +125,19 @@ For the final solution four different Patient-Classifier-Networks have been empl
 
 **Test system:**     </br>
 
-| Component | Spec  | Count | 
-|-----------|-------|-------|
+```eval_rst
++-----------+--------------------------------+-------+
+| Component | Spec                           | Count |
++===========+================================+=======+
 | CPU       | Intel(R) Core(TM) i7-4930K CPU |       |
-| GPU       | Nvidia GTX 1080 |       |
-| RAM       | 32GB  |       |
-|           | 200GB |       |
++-----------+--------------------------------+-------+
+| GPU       | Nvidia GTX 1080                |       |
++-----------+--------------------------------+-------+
+| RAM       | 32GB                           |       |
++-----------+--------------------------------+-------+
+|           | 200GB                          |       |
++-----------+--------------------------------+-------+
+```
 
 **Training time:**  from the [training log](https://github.com/NDKoehler/DataScienceBowl2017_7th_place/blob/5ff69f779ddbb1a3bf46f04b2312d4418c0ba6d2/dsb3_networks/classification/luna_resnet3D/output_dir/luna3D/all.log) it seems that one 3D resnet model requires 13 epochs with average 750s per epoch. For the 2D resnet from the coresponding [train log](https://raw.githubusercontent.com/NDKoehler/DataScienceBowl2017_7th_place/5ff69f779ddbb1a3bf46f04b2312d4418c0ba6d2/dsb3_networks/classification/luna_resnet2D/output_dir/gold_prio3_plane_mil0/all.log) folloed that the authors train the model over 17 epochs with the average 150s per epoch. Taking into account that there're two classification models of each type the resulting training time of the classification part will consume about 7 hours. </br>
 **Prediction time:** unknown, but must be less than 14 min per CT, since it processes the 506 CTs for the 5 days </br>
@@ -121,9 +146,13 @@ For the final solution four different Patient-Classifier-Networks have been empl
 
 **Dataset:**  Data Science Bowl evaluation dataset </br>
 
-| Metric   | Score |
-|----------|-------|
+```eval_rst
++----------+---------+
+| Metric   | Score   |
++==========+=========+
 | Log Loss | 0.42751 |
++----------+---------+
+```
 
 ## Use cases
 

--- a/docs/algorithms/algorithm_aidence.md
+++ b/docs/algorithms/algorithm_aidence.md
@@ -12,20 +12,31 @@ The 3rd place at the Data Science Bowl 2017 on the private leaderboard.
 
 ## Prerequisites
 
-| Dependency |   Name   | Version  |
-|------------|----------|----------|
-| Language   | Python   | 3.4      |
-| ML engine  |          |          |
-| ML backend | Tensorflow | 1.1    |
-| OS         |          |          |
-| Processor  | CPU      | yes      |
-|            | GPU      | Nvidia K80 |
-| GPU driver | CUDA     | 8.0      |
-|            | cuDNN    | 6.0      |
-
+```eval_rst
++------------+------------+------------+
+| Dependency |   Name     | Version    |
++============+============+============+
+| Language   | Python     | 3.4        |
++------------+------------+------------+
+| ML engine  |            |            |
++------------+------------+------------+
+| ML backend | Tensorflow | 1.1        |
++------------+------------+------------+
+| OS         |            |            |
++------------+------------+------------+
+| Processor  | CPU        | yes        |
++------------+------------+------------+
+|            | GPU        | Nvidia K80 |
++------------+------------+------------+
+| GPU driver | CUDA       | 8.0        |
++------------+------------+------------+
+|            | cuDNN      | 6.0        |
++------------+------------+------------+
+```
 
 **Dependency packages:**
-```
+
+```python
 tensorflow==1.1
 opencv>=3.1
 scipy==0.17.0
@@ -63,12 +74,21 @@ There are two `.pkl` models in [localization](https://bitbucket.org/aidence/kagg
 
 **Test system:**     </br>
 
-| Component | Spec  | Count | 
-|-----------|-------|-------|
-| CPU       |       |       |
-| GPU       | Nvidia K80 | 4 for everything but the final model <br/> 8 for the final model  |
-| RAM       |       |       |
-
+```eval_rst
++-----------+------------+------------------+
+| Component | Spec       | Count            |
++===========+============+==================+
+| CPU       |            |                  |
++-----------+------------+------------------+
+| GPU       | Nvidia K80 | 4 for everything |
+|           |            | but the final    |
+|           |            | model <br/> 8    |
+|           |            | for the final    |
+|           |            | model            |
++-----------+------------+------------------+
+| RAM       |            |                  |
++-----------+------------+------------------+
+```
 
 **Training time:** 
 >It takes about 3-5 days to run everything (infer+train) on a decent machine with 8 GPUs. </br>  
@@ -79,9 +99,13 @@ unknown, but must be less than 14 min per CT, since it processes the 506 CTs for
 
 **Dataset:**  Data Science Bowl evaluation dataset </br>
 
-| Metric   | Score |
-|----------|-------|
+```eval_rst
++----------+---------+
+| Metric   | Score   |
++==========+=========+
 | Log Loss | 0.40127 |
++----------+---------+
+```
 
 ## Use cases
 

--- a/docs/algorithms/algorithm_alex_andre_gilberto_shize.md
+++ b/docs/algorithms/algorithm_alex_andre_gilberto_shize.md
@@ -98,19 +98,31 @@ Some of the cells' values were restored from the AWSs' setups and CUDA compatibi
 
 **Dependency packages:** Neither the repository nor the authors specified exact versions of the Python packages:
 
-
-Andre         | Shize
---------------|---------------------------------
-Keras 1.2.2   | numpy
-Theano        | pandas
-spyder        | xgboost
-opencv        | scikit-learn
-pydicom       |
-scipy         |
-scikit-image  |
-SimpleITK     |
-numpy         |
-pandas        |
+```eval_rst
++-------------+--------------+
+| Andre       | Shize        |
++=============+==============+
+| Keras 1.2.2 | numpy        |
++-------------+--------------+
+| Theano      | pandas       |
++-------------+--------------+
+| spyder      | xgboost      |
++-------------+--------------+
+| opencv      | scikit-learn |
++-------------+--------------+
+| pydicom     |              |
++-------------+--------------+
+| scipy       |              |
++-------------+--------------+
+| scikit-image|              |
++-------------+--------------+
+| SimpleITK   |              |
++-------------+--------------+
+| numpy       |              |
++-------------+--------------+
+| pandas      |              |
++-------------+--------------+
+```
 
 ## Algorithm design
 
@@ -144,11 +156,17 @@ The authors also have mentioned that the code location of nodules versus the seg
 
 **Test system:**     </br>
 
-| Component | Spec  | Count |
-|-----------|-------|-------|
-| CPU       | C3.8 Intel Xeon |       |
+```eval_rst
++-----------+--------------------+-------+
+| Component | Spec               | Count |
++===========+====================+=======+
+| CPU       | C3.8 Intel Xeon    |       |
++-----------+--------------------+-------+
 | GPU       | P2 NVIDIA K80 12GB |  >1   |
-| RAM       |       |       |
++-----------+--------------------+-------+
+| RAM       |                    |       |
++-----------+--------------------+-------+
+```
 
 **Training time:** days on AWS
 >Training some of the nodule models took days using high end 12GB GPUs.</br>   
@@ -159,9 +177,13 @@ The authors also have mentioned that the code location of nodules versus the seg
 
 **Dataset:** Data Science Bowl evaluation dataset  </br>
 
-| Metric   | Score |
-|----------|-------|
+```eval_rst
++----------+---------+
+| Metric   | Score   |
++==========+=========+
 | Log Loss | 0.43019 |
++----------+---------+
+```
 
 ## Use cases
 

--- a/docs/algorithms/algorithm_de_wit.md
+++ b/docs/algorithms/algorithm_de_wit.md
@@ -14,19 +14,32 @@ MIT
 
 
 ## Prerequisites
-| Dependency |   Name   | Version  |
-|------------|----------|----------|
-| Language   | Python   | 3.5 |
-| ML engine  | Keras    | 2.0.8 |
-| ML backend | Tensorflow| 1.3.0 |
-| OS         | Windows/Ubuntu |64 Bit|
-| Processor  | CPU      | yes  |
-|            | GPU      | yes |
-| GPU driver | CUDA     | 8.0 |
-|            | cuDNN    | 6.0 |
+
+```eval_rst
++------------+----------------+---------+
+| Dependency |   Name         | Version |
++============+================+=========+
+| Language   | Python         | 3.5     |
++------------+----------------+---------+
+| ML engine  | Keras          | 2.0.8   |
++------------+----------------+---------+
+| ML backend | Tensorflow     | 1.3.0   |
++------------+----------------+---------+
+| OS         | Windows/Ubuntu | 64 Bit  |
++------------+----------------+---------+
+| Processor  | CPU            | yes     |
++------------+----------------+---------+
+|            | GPU            | yes     |
++------------+----------------+---------+
+| GPU driver | CUDA           | 8.0     |
++------------+----------------+---------+
+|            | cuDNN          | 6.0     |
++------------+----------------+---------+
+```
 
 **Dependency packages:**
-````
+
+```python
 beautifulsoup4==4.6.0
 lxml==3.8.0
 numpy==1.13.1
@@ -40,7 +53,7 @@ xgboost==0.6a2
 opencv-python==3.3.0.10
 pydicom==0.9.9
 SimpleITK==1.0.1
-````
+```
 
 ## Algorithm design
 ![](http://juliandewit.github.io/images/plan2017_2.png)
@@ -83,11 +96,17 @@ The masses detector is already run through the step2_train_mass_segmenter.py and
 Unfortunately, neither the blog entry nor the readme mention the system that was used for training and testing.  
 **Test system:**
 
-| Component | Spec  | Count |
-|-----------|-------|-------|
-| CPU       |       |       |
-| GPU       |       |       |
-| RAM       |       |       |
+```eval_rst
++-----------+------+-------+
+| Component | Spec | Count |
++===========+======+=======+
+| CPU       |      |       |
++-----------+------+-------+
+| GPU       |      |       |
++-----------+------+-------+
+| RAM       |      |       |
++-----------+------+-------+
+```
 
 **Training time:**  10 hours per 3D ConvNet  
 **Prediction time:** unknown  
@@ -96,9 +115,13 @@ Unfortunately, neither the blog entry nor the readme mention the system that was
 
 **Dataset:** Data Science Bowl 2017  
 
+```eval_rst
++----------+-------+
 | Metric   | Score |
-|----------|-------|
++==========+=======+
 | Log-Loss |0.40117|
++----------+-------+
+```
 
 ## Use cases
 

--- a/docs/algorithms/algorithm_deep_breath.md
+++ b/docs/algorithms/algorithm_deep_breath.md
@@ -14,29 +14,39 @@ The approach scored 9th place at the Data Science Bowl 2017.
 ## License
 [MIT](http://opensource.org/licenses/MIT) license
 
-
 ## Prerequisites
 
+```eval_rst
++------------+----------+----------+
 | Dependency |   Name   | Version  |
-|------------|----------|----------|
++============+==========+==========+
 | Language   | Python   |   2.7    |
++------------+----------+----------+
 | ML engine  | Lasagne  | 0.2.dev1 |
++------------+----------+----------+
 | ML backend | Theano   | 0.9.0b1  |
++------------+----------+----------+
 | OS         | Ubuntu   |  16.04   |
++------------+----------+----------+
 | Processor  | CPU      | yes      |
++------------+----------+----------+
 |            | GPU      | yes      |
++------------+----------+----------+
 | GPU driver | CUDA     |   8      |
++------------+----------+----------+
 |            | cuDNN    |   5.1    |
-
++------------+----------+----------+
+```
 
 **Dependency packages:**
-```
-theano 0.9.0b1
-lasagne 0.2.dev1
-scikit-image 0.12.3
-scipy 0.18.1
-numpy 1.12.0
-scikit-learn 0.18.1
+
+```python
+theano==0.9.0b1
+lasagne==0.2.dev1
+scikit-image==0.12.3
+scipy==0.18.1
+numpy==1.12.0
+scikit-learn==0.18.1
 ```
 
 
@@ -153,9 +163,13 @@ CPU: mostly 6 cores, 3GHz to 4GHz
 
 **Dataset:**    </br>
 
+```eval_rst
++----------+-------+
 | Metric   | Score |
-|----------|-------|
++==========+=======+
 | Accuracy |       |
++----------+-------+
+```
 
 ## Use cases
 <!-- List strengths and weaknesses of the algorithm. -->

--- a/docs/algorithms/algorithm_grt123.md
+++ b/docs/algorithms/algorithm_grt123.md
@@ -6,7 +6,7 @@ The model receives preprocessed 3D lung scans as
 input and outputs both the bounding boxes of suspicious nodules and the probability of getting cancer.
 
 ## Source
-**Author:** Team grt123      
+**Author:** Team grt123
 **Repository:** https://github.com/lfz/DSB2017  
 1st place at the Data Science Bowl 2017
 
@@ -16,22 +16,33 @@ Neither mentioned in the repository nor in the technical report, but since the a
 
 ## Prerequisites
 
-| Dependency |   Name   | Version  |
-|------------|----------|----------|
-| Language   | Python   |   2.7    |
+```eval_rst
++------------+----------+----------------+
+| Dependency |   Name   | Version        |
++============+==========+================+
+| Language   | Python   |   2.7          |
++------------+----------+----------------+
 | ML engine  | pyTorch  | 0.1.10+ac9245a |
-| ML backend |          |          |
-| OS         | Ubuntu   |  14.04   |
-| Processor  | CPU      |  yes     |
-|            | GPU      |  yes     |
-| GPU driver | CUDA     |  8.0     |
-|            | cuDNN    |  5.1     |
-
++------------+----------+----------------+
+| ML backend |          |                |
++------------+----------+----------------+
+| OS         | Ubuntu   |  14.04         |
++------------+----------+----------------+
+| Processor  | CPU      |  yes           |
++------------+----------+----------------+
+|            | GPU      |  yes           |
++------------+----------+----------------+
+| GPU driver | CUDA     |  8.0           |
++------------+----------+----------------+
+|            | cuDNN    |  5.1           |
++------------+----------+----------------+
+```
 
 **Dependency packages:**
-```
-h5py==2.6.0  
-SimpleITK==0.10.0  
+
+```python
+h5py==2.6.0
+SimpleITK==0.10.0
 numpy==1.11.3
 nvidia-ml-py==7.352.0
 matplotlib==2.0.0
@@ -95,12 +106,19 @@ Running [main.py](https://github.com/lfz/DSB2017/blob/master/main.py) should use
 
 **Test system:** </br>
 
-| Component | Spec  | Count |
-|-----------|-------|-------|
-| CPU       |       |       |
-| GPU       | TITAN X|   8   |
-| GPU       |Memory |>= 12GB|
-| RAM       |       |       |
+```eval_rst
++-----------+---------+--------+
+| Component | Spec    | Count  |
++===========+=========+========+
+| CPU       |         |        |
++-----------+---------+--------+
+| GPU       | TITAN X | 8      |
++-----------+---------+--------+
+| GPU       |Memory   | >= 12GB|
++-----------+---------+--------+
+| RAM       |         |        |
++-----------+---------+--------+
+```
 
 **Training time:**  4 days</br>
 **Prediction time:** </br>
@@ -109,9 +127,13 @@ Running [main.py](https://github.com/lfz/DSB2017/blob/master/main.py) should use
 
 **Dataset:** Private Kaggle Test Data
 
-| Metric   | Score |
-|----------|-------|
+```eval_rst
++----------+----------+
+| Metric   | Score    |
++==========+==========+
 | Log-Loss |  0.39975 |
++----------+----------+
+```
 
 ## Use cases
 

--- a/docs/algorithms/algorithm_hammack.md
+++ b/docs/algorithms/algorithm_hammack.md
@@ -14,16 +14,27 @@ Neither mentioned in the repository nor in the technical report, but since the a
 
 ## Prerequisites
 
-| Dependency |   Name   | Version  |
-|------------|----------|----------|
-| Language   | Python   |   2.7    |
-| ML engine  | Keras    |          |
-| ML backend | Theano, scikit-learn |      |
-| OS         |          |          |
-| Processor  | CPU      | yes      |
-|            | GPU      | yes      |
-| GPU driver | CUDA     |          |
-|            | cuDNN    |          |
+```eval_rst
++------------+----------------------+----------+
+| Dependency |   Name               | Version  |
++============+======================+==========+
+| Language   | Python               |   2.7    |
++------------+----------------------+----------+
+| ML engine  | Keras                |          |
++------------+----------------------+----------+
+| ML backend | Theano, scikit-learn |          |
++------------+----------------------+----------+
+| OS         |                      |          |
++------------+----------------------+----------+
+| Processor  | CPU                  | yes      |
++------------+----------------------+----------+
+|            | GPU                  | yes      |
++------------+----------------------+----------+
+| GPU driver | CUDA                 |          |
++------------+----------------------+----------+
+|            | cuDNN                |          |
++------------+----------------------+----------+
+```
 
 
 **Dependency packages:**
@@ -108,11 +119,17 @@ Another interesting fact is that the Z-dimension, so whether the nodule is close
 
 **Test system:**     </br>
 
-| Component | Spec  | Count |
-|-----------|-------|-------|
-| CPU       |       |       |
-| GPU       | Tesla K80 / amazon p2.xlarge  |    1   |
-| RAM       |       |       |
+```eval_rst
++-----------+-------------------------------+-------+
+| Component | Spec                          | Count |
++===========+===============================+=======+
+| CPU       |                               |       |
++-----------+-------------------------------+-------+
+| GPU       | Tesla K80 / amazon p2.xlarge  | 1     |
++-----------+-------------------------------+-------+
+| RAM       |                               |       |
++-----------+-------------------------------+-------+
+```
 
 **Training time:**  8 hours on K80 / 1.5 hours on AWS  
 **Prediction time:**  unknown
@@ -123,9 +140,13 @@ Another interesting fact is that the Z-dimension, so whether the nodule is close
 **Dataset:**
 Data Science Bowl evaluation dataset
 
-| Metric   | Score |
-|----------|-------|
+```eval_rst
++----------+---------+
+| Metric   | Score   |
++==========+=========+
 | Log Loss | 0.401172|
++----------+---------+
+```
 
 ## Use cases
 

--- a/docs/algorithms/algorithm_mdai.md
+++ b/docs/algorithms/algorithm_mdai.md
@@ -1,4 +1,3 @@
-<!-- Add the algorithm's name as the title -->
 # MDai Algorithm
 
 ## Summary
@@ -25,23 +24,34 @@ Also mention Placement. -->
 ## Prerequisites
 <!-- summary on dependencies needed to run the algorithm -->
 
-| Dependency |   Name   | Version  |
-|------------|----------|----------|
-| Language   | Python   | 3.5      | <!-- If not Python 3.5+ please describe steps to port into Python 3.5+ below -->
-| ML engine  | Keras    | 1.2.2    | <!-- e.g. Keras -->
-| ML backend | Tensorflow | 1.0.0  | <!-- e.g. Tensorflow -->
-| OS         | Ubuntu   |  16.04   | <!-- Include all OS that were tested -->
-| Processor  | CPU      | (yes/no) |
-|            | GPU      | yes      |
-| GPU driver | CUDA     | 8        |
-|            | cuDNN    | 5.1      |
+```eval_rst
++------------+------------+----------+
+| Dependency |   Name     | Version  |
++============+============+==========+
+| Language   | Python     | 3.5      |
++------------+------------+----------+
+| ML engine  | Keras      | 1.2.2    |
++------------+------------+----------+
+| ML backend | Tensorflow | 1.0.0    |
++------------+------------+----------+
+| OS         | Ubuntu     | 16.04    |
++------------+------------+----------+
+| Processor  | CPU        | (yes/no) |
++------------+------------+----------+
+|            | GPU        | yes      |
++------------+------------+----------+
+| GPU driver | CUDA       | 8        |
++------------+------------+----------+
+|            | cuDNN      | 5.1      |
++------------+------------+----------+
+```
 
 
 **Dependency packages:**
 <!-- List dependency packages (e.g. numpy) with version. If using python use requirements.txt syntax for pip. That makes
  easy for the developers. -->
- 
-````
+
+```python
 numpy==1.12.1
 scipy==0.19.0
 pandas==0.19.2
@@ -55,7 +65,7 @@ tensorflow-gpu==1.0.0
 hyperopt==0.1
 h5py==2.7.0
 redis-py==2.10.5
-````
+```
 
 **Additional installation instructions:** 
 
@@ -149,11 +159,17 @@ A trained model is not publicly available, but was requested.
 
 **Test system:**  AWS p2.16xlarge instance   </br>
 
-| Component | Spec  | Count |
-|-----------|-------|-------|
-| vCPU       | Broadwell 2.7 GHz |  64   |
-| GPU       | NVIDIA GK210 |  16   |
-| RAM       | 732 GB|       |
+```eval_rst
++-----------+-------------------+-------+
+| Component | Spec              | Count |
++===========+===================+=======+
+| vCPU      | Broadwell 2.7 GHz |  64   |
++-----------+-------------------+-------+
+| GPU       | NVIDIA GK210      |  16   |
++-----------+-------------------+-------+
+| RAM       | 732 GB            |       |
++-----------+-------------------+-------+
+```
 
 **Training time:**  Not specified. </br>
 **Prediction time:** Several days for the whole DSB dataset. </br>
@@ -163,9 +179,14 @@ A trained model is not publicly available, but was requested.
 
 **Dataset:**    </br>
 
-| Metric   | Score |
-|----------|-------|
+```eval_rst
++---------+---------+
+| Metric  | Score   |
++=========+=========+
 | LogLoss | 0.41629 |
++---------+---------+
+```
+
 
 ## Use cases
 <!-- List strengths and weaknesses of the algorithm. -->

--- a/docs/algorithms/algorithm_owkin.md
+++ b/docs/algorithms/algorithm_owkin.md
@@ -14,20 +14,31 @@ The repository doesn't mention a license but since the authors had to accept the
 
 ## Prerequisites
 
-| Dependency |   Name   | Version  |
-|------------|----------|----------|
-| Language   | Python   |    2.7   |
-| ML engine  |  Keras   |    2     |
-| ML backend |  Tensorflow | 1     |
-| OS         |          |          | <!-- Include all OS that were tested -->
-| Processor  | CPU      | (yes)      |
-|            | GPU      | yes      |
-| GPU driver | CUDA     |          |
-|            | cuDNN    |          |
-
+```eval_rst
++------------+------------+----------+
+| Dependency |   Name     | Version  |
++============+============+==========+
+| Language   | Python     |    2.7   |
++------------+------------+----------+
+| ML engine  |  Keras     |    2     |
++------------+------------+----------+
+| ML backend | Tensorflow | 1        |
++------------+------------+----------+
+| OS         |            |          |
++------------+------------+----------+
+| Processor  | CPU        | (yes)    |
++------------+------------+----------+
+|            | GPU        | yes      |
++------------+------------+----------+
+| GPU driver | CUDA       |          |
++------------+------------+----------+
+|            | cuDNN      |          |
++------------+------------+----------+
+```
 
 **Dependency packages:**
-````
+
+```python
 tensorflow-gpu
 keras
 SimpleITK
@@ -37,7 +48,7 @@ h5py
 opencv-python
 radiomics
 xgboost
-````
+```
 
 
 ## Algorithm design
@@ -98,25 +109,35 @@ python kaggle_predict.py -p /tmp/patch_model_features_test.csv -u /tmp/unet_feat
 
 ### Training- / prediction time
 
-**Test system:**  Unknown  
+**Test system:**  Unknown
 
+```eval_rst
++-----------+-------+-------+
 | Component | Spec  | Count |
-|-----------|-------|-------|
++===========+=======+=======+
 | CPU       |       |       |
++-----------+-------+-------+
 | GPU       |       |       |
++-----------+-------+-------+
 | RAM       |       |       |
++-----------+-------+-------+
+```
 
 **Training time:**  Unknown  
 **Prediction time:** 3 min per Patient for approach 1
 
 ### Model Evaluation
 
-**Dataset:**  
+**Dataset:**
 Data Science Bowl evaluation dataset
 
-| Metric   | Score |
-|----------|-------|
+```eval_rst
++----------+--------+
+| Metric   | Score  |
++==========+========+
 | Log Loss | 0.44068|
++----------+--------+
+```
 
 ## Use cases
 

--- a/docs/algorithms/algorithm_qfpxfd.md
+++ b/docs/algorithms/algorithm_qfpxfd.md
@@ -12,17 +12,17 @@ The 4th place at the Data Science Bowl 2017 on the private leaderboard.
 ## Prerequisites
 ```Unknown```
 
-| Dependency |   Name   | Version  |
-|------------|----------|----------|
-| Language   | Python   |   | 
-| ML engine  |  Keras        |          | 
-| ML backend | Tensorflow |   | 
-<!-- | OS         |  |  | 
-| Processor  | CPU      |  |
-|            | GPU      |  |
-| GPU driver | CUDA     |  |
-|            | cuDNN    |  |
--->
+```eval_rst
++------------+------------+----------+
+| Dependency |   Name     | Version  |
++============+============+==========+
+| Language   | Python     |          |
++------------+------------+----------+
+| ML engine  | Keras      |          |
++------------+------------+----------+
+| ML backend | Tensorflow |          |
++------------+------------+----------+
+```
 
 
 **Dependency packages:**
@@ -95,11 +95,19 @@ The competition performance metric (CPM, averaged FROC key-points' magnitude) sc
 
 **Dataset:**  Data Science Bowl evaluation dataset </br>
 
-|  Problem | Score |Metric| Dataset| 
-|----------|-------|--------|--------|
-|Lung Cancer Detection | Log Loss | 0.40183 | Kaggle|
-|False Positive Reduction |CPM | 0.891 | Luna16 |
-|Candidate Detection |Sensitivity </br> Candidates per scan | 0.946 </br> 15.0 | Luna16|
+```eval_rst
++-------------------------+---------------------+---------------+-------------+
+|  Problem                | Score               | Metric        | Dataset     |
++=========================+====================++===============+=============+
+|Lung Cancer Detection    | Log Loss            | 0.40183       | Kaggle      |
++-------------------------+---------------------+---------------+-------------+
+|False Positive Reduction | CPM                 | 0.891         | Luna16      |
++-------------------------+---------------------+---------------+-------------+
+|Candidate Detection      | Sensitivity </br>   | 0.946 </br>   | Luna16      |
++-------------------------+---------------------+---------------+-------------+
+|                         | Candidates per scan | 15.0          |             |
++-------------------------+---------------------+---------------+-------------+
+```
 
 ## Use cases
 

--- a/docs/algorithms/algorithm_therapixel.md
+++ b/docs/algorithms/algorithm_therapixel.md
@@ -16,22 +16,34 @@ GNU General Public License v3.0
 ## Prerequisites
 This is the recommended / tested environment
 
-| Dependency |   Name   | Version  |
-|------------|----------|----------|
-| Language   | Python   |   3.5    |
-| ML engine  |          |          |
-| ML backend |          |Tensorflow 1.1|
-| OS         | Ubuntu   |16.04 x64 |
-| Processor  | CPU      |2x Intel i7|
-|            | GPU      |4xNVIDIA Titan|
-| Alternative GPU| GPU  |NVIDIA NVIDIA P6000|
-| GPU driver | CUDA     |   8      |
-|            | cuDNN    |   5.1    |
-
+```eval_rst
++----------------+-----------+----------------------+
+| Dependency     |  Name     |  Version             |
++================+===========+======================+
+| Language       | Python    |  3.5                 |
++----------------+-----------+----------------------+
+| ML engine      |           |                      |
++----------------+-----------+----------------------+
+| ML backend     |           |  Tensorflow 1.1      |
++----------------+-----------+----------------------+
+| OS             | Ubuntu    |  16.04 x64           |
++----------------+-----------+----------------------+
+| Processor      | CPU       |  2x Intel i7         |
++----------------+-----------+----------------------+
+|                | GPU       |  4xNVIDIA Titan      |
++----------------+-----------+----------------------+
+| Alternative GPU| GPU       |  NVIDIA NVIDIA P6000 |
++----------------+-----------+----------------------+
+| GPU driver     | CUDA      |  8                   |
++----------------+-----------+----------------------+
+|                | cuDNN     |  5.1                 |
++----------------+-----------+----------------------+
+```
 
 **Dependency packages:**
 All dependencies have been installed using `pip3`.
-````
+
+```python
 https://github.com/pfillard/tensorflow/tree/r1.0_relu1
 xgboost
 numpy
@@ -40,7 +52,7 @@ skimage
 SimpleITK
 h5py
 optparse
-````
+```
 
 
 ## Algorithm design
@@ -90,12 +102,17 @@ Lastly, XGBoost predicts the cancer probability based on these features.
 Unknown  
 **Test system:**     </br>
 
+```eval_rst
++-----------+-------+-------+
 | Component | Spec  | Count |
-|-----------|-------|-------|
++===========+=======+=======+
 | CPU       |       |       |
++-----------+-------+-------+
 | GPU       |       |       |
-| GPU       |       |       |
++-----------+-------+-------+
 | RAM       |       |       |
++-----------+-------+-------+
+```
 
 **Training time:**  </br>
 **Prediction time:** </br>
@@ -104,9 +121,13 @@ Unknown
 
 **Dataset:** Data Science Bowl 2017
 
-| Metric   | Score |
-|----------|-------|
-| Accuracy |0.40409|
+```eval_rst
++----------+--------+
+| Metric   | Score  |
++==========+========+
+| Log Loss | 0.40409|
++----------+--------+
+```
 
 ## Use cases
 

--- a/docs/algorithms/algorithms_doc.rst
+++ b/docs/algorithms/algorithms_doc.rst
@@ -1,0 +1,17 @@
+Algorithms
+=========
+
+.. toctree::
+   :maxdepth: 2
+
+   algorithm_aidence
+   algorithm_alex_andre_gilberto_shize
+   algorithm_de_wit
+   algorithm_deep_breath
+   algorithm_DL_Munich
+   algorithm_grt123
+   algorithm_hammack
+   algorithm_mdai
+   algorithm_owkin
+   algorithm_qfpxfd
+   algorithm_therapixel

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,7 @@
 import os
 import sys
 import django
+from recommonmark.transform import AutoStructify
 
 DOCS_DIR = os.getcwd()
 PROJECT_DIR = os.path.abspath(os.path.join(DOCS_DIR, os.pardir))
@@ -167,3 +168,7 @@ source_parsers = {
 
 def setup(app):
     app.add_stylesheet('c2c_custom.css')
+    app.add_config_value('recommonmark_config', {
+        'enable_eval_rst': True
+    }, True)
+    app.add_transform(AutoStructify)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,13 @@ Welcome to Concept to Clinic's documentation!
    code-of-conduct-link
    contributor-license-agreement-link
 
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Algorithms Documentation
+
+   algorithms/algorithms_doc
+
 .. toctree::
   :maxdepth: 2
   :caption: Documentation

--- a/docs/templates/algorithm_doc_template.md
+++ b/docs/templates/algorithm_doc_template.md
@@ -18,17 +18,33 @@ Also mention Placement. -->
 ## Prerequisites
 <!-- summary on dependencies needed to run the algorithm -->
 
-| Dependency |   Name   | Version  |
-|------------|----------|----------|
-| Language   | Python   |          | <!-- If not Python 3.5+ please describe steps to port into Python 3.5+ below -->
-| ML engine  |          |          | <!-- e.g. Keras -->
-| ML backend |          |          | <!-- e.g. Tensorflow -->
-| OS         |          |          | <!-- Include all OS that were tested -->
-| Processor  | CPU      | (yes/no) |
-|            | GPU      | (yes/no) |
-| GPU driver | CUDA     |          |
-|            | cuDNN    |          |
+<!-- NOTE: The tables are created using reST markup syntax inside of a markdown file.
+Ensure that your table data fits correctly so that your table is displayed. You
+can reference this site(https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html#tables)
+or look at existing algorithm files for cases like long lines and how you can wrap
+them in rows to avoid long text lines. -->
 
+```eval_rst
++------------+----------+----------+
+| Dependency |   Name   | Version  |
++============+==========+==========+
+| Language   | Python   |          | <!-- If not Python 3.5+ please describe steps to port into Python 3.5+ below -->
++------------+----------+----------+
+| ML engine  |          |          | <!-- e.g. Keras -->
++------------+----------+----------+
+| ML backend |          |          | <!-- e.g. Tensorflow -->
++------------+----------+----------+
+| OS         |          |          | <!-- Include all OS that were tested -->
++------------+----------+----------+
+| Processor  | CPU      | (yes/no) |
++------------+----------+----------+
+|            | GPU      | (yes/no) |
++------------+----------+----------+
+| GPU driver | CUDA     |          |
++------------+----------+----------+
+|            | cuDNN    |          |
++------------+----------+----------+
+```
 
 **Dependency packages:**
 <!-- List dependency packages (e.g. numpy) with version. If using python use requirements.txt syntax for pip. That makes
@@ -60,11 +76,17 @@ Also mention Placement. -->
 
 **Test system:**     </br>
 
+```eval_rst
++-----------+-------+-------+
 | Component | Spec  | Count |
-|-----------|-------|-------|
++===========+=======+=======+
 | CPU       |       |       |
++-----------+-------+-------+
 | GPU       |       |       |
++-----------+-------+-------+
 | RAM       |       |       |
++-----------+-------+-------+
+```
 
 **Training time:**  </br>
 **Prediction time:** </br>
@@ -74,9 +96,13 @@ Also mention Placement. -->
 
 **Dataset:**    </br>
 
+```eval_rst
++----------+-------+
 | Metric   | Score |
-|----------|-------|
++==========+=======+
 | Accuracy |       |
++----------+-------+
+```
 
 ## Use cases
 <!-- List strengths and weaknesses of the algorithm. -->


### PR DESCRIPTION
## Description
Add algorithm documentation pages to the docs table of contents

## Reference to official issue
Addresses issue #258 

## Motivation and Context
Adds algorithms documentation to the `toc tree`

## How Has This Been Tested?
- `docker-compose -f local.yml up`
- Navigate to [http://localhost:8002/](http://localhost:8002)
- The table of contents has the **Algorithms** section under **Code Documentation**

## Not done
~~The algorithm doc files are in `markdown`. Most of them have tables and they're not well displayed on the pages (parsed as paragraphs 🙄 ). Some searching brought me across to this [stackoverflow answer](https://stackoverflow.com/a/44463828/4444629). Basically, to display the tables the best approach is to use `reST` mark up files.~~

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
