### PR TITLE
fixed candidate select\deselect API test

### DIFF
--- a/interface/backend/api/tests.py
+++ b/interface/backend/api/tests.py
@@ -3,6 +3,7 @@ import os
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
+from rest_framework.test import APITestCase
 
 from backend.api.serializers import (
     ImageFileSerializer,
@@ -20,8 +21,10 @@ from backend.cases.factories import (
     CandidateFactory
 )
 
+from backend.cases import enums
 
-class ViewTest(TestCase):
+
+class ViewTest(APITestCase):
     def test_nodule_list_viewset(self):
         # first try an endpoint without a nodule
         url = reverse('nodule-list')
@@ -89,6 +92,22 @@ class ViewTest(TestCase):
             'dicom_location': '/images/does_not_exist'
         })
         self.assertEqual(response.status_code, 404)
+
+    def test_candidates_mark(self):
+        candidate = CandidateFactory()
+
+        url = reverse('candidate-detail', kwargs={'pk': candidate.id})
+        response = self.client.patch(url, {'review_result': enums.CandidateReviewResult.MARKED.value})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_candidates_dismiss(self):
+        candidate = CandidateFactory()
+
+        url = reverse('candidate-detail', kwargs={'pk': candidate.id})
+        response = self.client.patch(url, {'review_result': enums.CandidateReviewResult.DISMISSED.value})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
 class SerializerTest(TestCase):

--- a/interface/backend/cases/tests.py
+++ b/interface/backend/cases/tests.py
@@ -69,7 +69,7 @@ class SmokeTest(APITestCase):
             'patient_id': '42',
             'series_instance_uid': '13',
             'uri': '/images/1.dcm',
-            'url': '/api/images/7/',
+            'url': '/api/images/9/',
             'images': [],
         }
         self.assertDictEqual(expected, response.data['series'])


### PR DESCRIPTION
Small fix of the candidates API tests based on this [discussion](https://github.com/concept-to-clinic/concept-to-clinic/pull/254#issuecomment-348448307).

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
