### PR TITLE
DICOM viewer: zoom and pan support

### DIFF
--- a/interface/frontend/src/components/common/OpenDICOM.vue
+++ b/interface/frontend/src/components/common/OpenDICOM.vue
@@ -6,7 +6,7 @@
         class="DICOM-range"
         type="range"
         min="0"
-        v-bind:max="view.paths.length"
+        v-bind:max="view.paths.length - 1"
         v-bind:value="stack.currentImageIdIndex"
         v-on:input="rangeSlice($event)"
       >

--- a/interface/frontend/src/components/common/OpenDICOM.vue
+++ b/interface/frontend/src/components/common/OpenDICOM.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="DICOM-container" style="width: 100%">
+  <div class="DICOM-container">
     <div class="DICOM-description">{{ display }}</div>
     <div class="DICOM-toolbar" v-if="view.paths.length">
       <input
@@ -12,7 +12,7 @@
       >
       slice index: <b>{{ stack.currentImageIdIndex }} </b>
     </div>
-    <div class="DICOM" ref="DICOM" style="width: 100%"></div>
+    <div class="DICOM" ref="DICOM"></div>
     <nodule-marker :marker="marker" :sliceIndex="stack.currentImageIdIndex" :zoomRate="zoomRate" :offsetX="offsetX" :offsetY="offsetY"></nodule-marker>
     <area-select @selection-changed="areaSelectChange" v-if="showAreaSelect" :areaCoordinates="areaCoordinates"></area-select>
   </div>

--- a/interface/frontend/src/components/common/OpenDICOM.vue
+++ b/interface/frontend/src/components/common/OpenDICOM.vue
@@ -88,12 +88,14 @@
             } else {
               hola = await this.$axios.get(this.view.prefixUrl + this.view.paths[this.stack.currentImageIdIndex])
             }
+
             this.pool[this.stack.currentImageIdIndex] = hola
-            return hola
           } else {
             console.log('No path in paths for index ', this.stack.currentImageIdIndex)
           }
         }
+
+        return this.pool[this.stack.currentImageIdIndex]
       },
       async dicom () {
         let info = await this.info

--- a/interface/frontend/src/components/common/OpenDICOM.vue
+++ b/interface/frontend/src/components/common/OpenDICOM.vue
@@ -25,7 +25,6 @@
   const cornerstone = require('cornerstone-core')
   const cornerstoneTools = require('cornerstone-tools')
   const cornerstoneMath = require('cornerstone-math')
-  const _ = require('lodash')
 
   cornerstoneTools.external.cornerstone = cornerstone
   cornerstoneTools.external.cornerstoneMath = cornerstoneMath
@@ -98,7 +97,7 @@
       },
       async dicom () {
         let info = await this.info
-        if (!info || !info.data) return {}
+        if (!info || !info.data) return null
         else {
           info = info.data
           this.base64data = info.image
@@ -126,7 +125,7 @@
       async display () {
         const element = this.$refs.DICOM
         const dicom = await this.dicom
-        if (_.isEmpty(dicom)) return ''
+        if (!dicom) return ''
         else {
           cornerstone.registerImageLoader(this.view.type, () => {
             return {promise: new Promise((resolve) => { resolve(dicom) })}


### PR DESCRIPTION
Enabled window width and window center adjustment. Enabled zooming and panning. 
Updated the `NoduleMarker` component to rescale and move the marker accordingly.
Fixed bug - moving slider to cached slices didn't show those slices.

## Reference to official issue
#240 

## Screenshot
![zoom, pan](http://g.recordit.co/WF64msW6C0.gif)

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
