### PR TITLE
fixed classification prediction for multiple nodules

### DIFF
--- a/prediction/src/preprocess/crop_patches.py
+++ b/prediction/src/preprocess/crop_patches.py
@@ -81,8 +81,8 @@ def crop_patch(ct_array, meta, patch_shape=None, centroids=None, stride=None, pa
                                      indexing='ij')
             coord = np.concatenate([xx[np.newaxis, ...], yy[np.newaxis, ...], zz[np.newaxis, :]], 0).astype('float32')
             yield patch, coord
-
-        yield patch
+        else:
+            yield patch
 
 
 def patches_from_ct(ct_array, meta, patch_shape=None, centroids=None, stride=None, pad_value=0):


### PR DESCRIPTION
Bug fixed. When the length of the nodules list is more then 1 – prediction fails as follows:

```
~/concept-to-clinic/prediction/src/algorithms/classify/src/gtr123_model.py in predict(ct_path, nodule_list, model_path)
    275     results = []
    276 
--> 277     for nodule, (cropped_image, coords) in zip(nodule_list, patches):
    278         cropped_image = Variable(torch.from_numpy(cropped_image[np.newaxis, np.newaxis]).float())
    279         cropped_image.volatile = True

ValueError: too many values to unpack (expected 2)
```

More details [here](https://github.com/concept-to-clinic/concept-to-clinic/pull/272#issuecomment-355413434).

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well

  