### PR TITLE
Add Python Coverage Report

### DIFF
--- a/prediction/requirements/local.txt
+++ b/prediction/requirements/local.txt
@@ -1,3 +1,4 @@
 flake8==3.3.0
 pytest==3.1.3
 pylidc==0.1.9 # Fixes UnicodeDecodeError in to_volume() (https://github.com/pylidc/pylidc/issues/9)
+coverage==4.4.2

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -7,10 +7,14 @@
 set -ex
 
 # run the model service's tests
-docker-compose -f local.yml run prediction pytest -rsx
+# Coverage should ignore pip packets, files including tests and pytest
+docker-compose -f local.yml run prediction coverage run --branch --omit=/**/dist-packages/*,src/tests/*,/usr/local/bin/pytest /usr/local/bin/pytest -rsx
+docker-compose -f local.yml run prediction coverage report
 
 # run the backend API tests
-docker-compose -f local.yml run interface python manage.py test
+# Coverage should ignore pip packets, files including migrations and tests
+docker-compose -f local.yml run interface coverage run --branch --omit=/**/dist-packages/*,**/migrations/*.py,**/test*.py manage.py test
+docker-compose -f local.yml run interface coverage report
 
 # return non-zero status code if there are migrations that have not been created
 docker-compose -f local.yml run interface python manage.py makemigrations --dry-run --check || { echo "ERROR: there were changes in the models, but migration listed above have not been created and are not saved in version control"; exit 1; }


### PR DESCRIPTION
As discussed in #275, it would be helpful to generate a coverage report of the unit tests in which the total coverage and missing lines can be seen. This PR adds [Coverage.py](https://coverage.readthedocs.io/en/coverage-4.4.2/) which keeps track of which LOC haven't been tested after running the tests. It generates a `htmlcov` directory which includes the HTML files that should be served afterwards to correctly render the report. Examples of such reports for the current master are here: [prediction](https://wgierke.github.io/stuff/prediction/index.html), [interface](https://wgierke.github.io/stuff/interface/index.html).

To persist this report generated by Travis, the project manager need to [set up Travis artifacts](https://docs.travis-ci.com/user/uploading-artifacts/).


## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well

  