### PR TITLE
/<algorithm>/predict/: Only expect GET or POST requests

### DIFF
--- a/prediction/src/views.py
+++ b/prediction/src/views.py
@@ -73,7 +73,7 @@ def predict(algorithm):
         response.update({'description': PREDICTORS[algorithm].__doc__})
 
     # make predictions on POST
-    elif request.method == 'POST':
+    else:
         payload = request.json
 
         try:


### PR DESCRIPTION
While skimming through [code that still needs to be tested in the prediction service](https://wgierke.github.io/stuff/prediction/index.html), I noticed this line that prevented the file from being completely covered by tests. The reason was that the condition was never false since the `methods=['GET', 'POST']` parameter prevents any other request than a `POST` request from reaching this LOC.

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
