### PR TITLE
#271 LUNA16 evaluation

### DIFF
--- a/prediction/src/evaluations/froc.py
+++ b/prediction/src/evaluations/froc.py
@@ -1,0 +1,594 @@
+import csv
+import math
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import sklearn.metrics as skl_metrics
+from NoduleFinding import NoduleFinding
+from matplotlib.ticker import FixedFormatter
+
+# Evaluation settings
+bPerformBootstrapping = True
+bNumberOfBootstrapSamples = 1000
+bOtherNodulesAsIrrelevant = True
+bConfidence = 0.95
+
+seriesuid_label = 'seriesuid'
+coordX_label = 'coordX'
+coordY_label = 'coordY'
+coordZ_label = 'coordZ'
+diameter_mm_label = 'diameter_mm'
+CADProbability_label = 'probability'
+
+# plot settings
+FROC_minX = 0.125  # Mininum value of x-axis of FROC curve
+FROC_maxX = 8  # Maximum value of x-axis of FROC curve
+bLogPlot = True
+
+
+def writeCSV(filename, lines):
+    with open(filename, "w") as f:
+        csvwriter = csv.writer(f)
+        csvwriter.writerows(lines)
+
+
+def readCSV(filename):
+    lines = []
+    with open(filename, "r") as f:
+        csvreader = csv.reader(f)
+        for line in csvreader:
+            lines.append(line)
+    return lines
+
+
+def tryFloat(value):
+    try:
+        value = float(value)
+    except:
+        value = value
+
+    return value
+
+
+def getColumn(lines, columnid, elementType=''):
+    column = []
+    for line in lines:
+        try:
+            value = line[columnid]
+        except:
+            continue
+
+        if elementType == 'float':
+            value = tryFloat(value)
+
+        column.append(value)
+
+    return column
+
+
+class NoduleFinding(object):
+    '''
+    Represents a nodule
+    '''
+
+    def __init__(self, noduleid=None, coordX=None, coordY=None, coordZ=None, coordType="World",
+                 CADprobability=None, noduleType=None, diameter=None, state=None, seriesInstanceUID=None):
+        # set the variables and convert them to the correct type
+        self.id = noduleid
+        self.coordX = coordX
+        self.coordY = coordY
+        self.coordZ = coordZ
+        self.coordType = coordType
+        self.CADprobability = CADprobability
+        self.noduleType = noduleType
+        self.diameter_mm = diameter
+        self.state = state
+        self.candidateID = None
+        self.seriesuid = seriesInstanceUID
+
+
+def generateBootstrapSet(scanToCandidatesDict, FROCImList):
+    '''
+    Generates bootstrapped version of set
+    '''
+    imageLen = FROCImList.shape[0]
+
+    # get a random list of images using sampling with replacement
+    rand_index_im = np.random.randint(imageLen, size=imageLen)
+    FROCImList_rand = FROCImList[rand_index_im]
+
+    # get a new list of candidates
+    candidatesExists = False
+    for im in FROCImList_rand:
+        if im not in scanToCandidatesDict:
+            continue
+
+        if not candidatesExists:
+            candidates = np.copy(scanToCandidatesDict[im])
+            candidatesExists = True
+        else:
+            candidates = np.concatenate((candidates, scanToCandidatesDict[im]), axis=1)
+
+    return candidates
+
+
+def compute_mean_ci(interp_sens, confidence=0.95):
+    sens_mean = np.zeros((interp_sens.shape[1]), dtype='float32')
+    sens_lb = np.zeros((interp_sens.shape[1]), dtype='float32')
+    sens_up = np.zeros((interp_sens.shape[1]), dtype='float32')
+
+    Pz = (1.0 - confidence) / 2.0
+
+    for i in range(interp_sens.shape[1]):
+        # get sorted vector
+        vec = interp_sens[:, i]
+        vec.sort()
+
+        sens_mean[i] = np.average(vec)
+        sens_lb[i] = vec[math.floor(Pz * len(vec))]
+        sens_up[i] = vec[math.floor((1.0 - Pz) * len(vec))]
+
+    return sens_mean, sens_lb, sens_up
+
+
+def computeFROC_bootstrap(FROCGTList, FROCProbList,
+                          FPDivisorList, FROCImList,
+                          excludeList, numberOfBootstrapSamples=1000, confidence=0.95):
+    set1 = np.concatenate(([FROCGTList], [FROCProbList], [excludeList]), axis=0)
+
+    fps_lists = []
+    sens_lists = []
+    thresholds_lists = []
+
+    FPDivisorList_np = np.asarray(FPDivisorList)
+    FROCImList_np = np.asarray(FROCImList)
+
+    # Make a dict with all candidates of all scans
+    scanToCandidatesDict = {}
+    for i in range(len(FPDivisorList_np)):
+        seriesuid = FPDivisorList_np[i]
+        candidate = set1[:, i:i + 1]
+
+        if seriesuid not in scanToCandidatesDict:
+            scanToCandidatesDict[seriesuid] = np.copy(candidate)
+        else:
+            scanToCandidatesDict[seriesuid] = np.concatenate((scanToCandidatesDict[seriesuid], candidate), axis=1)
+
+    for i in range(numberOfBootstrapSamples):
+        print('computing FROC: bootstrap %d/%d' % (i, numberOfBootstrapSamples))
+        # Generate a bootstrapped set
+        btpsamp = generateBootstrapSet(scanToCandidatesDict, FROCImList_np)
+        fps, sens, thresholds = computeFROC(btpsamp[0, :], btpsamp[1, :], len(FROCImList_np), btpsamp[2, :])
+
+        fps_lists.append(fps)
+        sens_lists.append(sens)
+        thresholds_lists.append(thresholds)
+
+    # compute statistic
+    all_fps = np.linspace(FROC_minX, FROC_maxX, num=10000)
+
+    # Then interpolate all FROC curves at this points
+    interp_sens = np.zeros((numberOfBootstrapSamples, len(all_fps)), dtype='float32')
+    for i in range(numberOfBootstrapSamples):
+        interp_sens[i, :] = np.interp(all_fps, fps_lists[i], sens_lists[i])
+
+    # compute mean and CI
+    sens_mean, sens_lb, sens_up = compute_mean_ci(interp_sens, confidence=confidence)
+
+    return all_fps, sens_mean, sens_lb, sens_up
+
+
+def computeFROC(FROCGTList, FROCProbList,
+                totalNumberOfImages, excludeList):
+    # Remove excluded candidates
+    FROCGTList_local = []
+    FROCProbList_local = []
+    for i in range(len(excludeList)):
+        if excludeList[i] == False:
+            FROCGTList_local.append(FROCGTList[i])
+            FROCProbList_local.append(FROCProbList[i])
+
+    numberOfDetectedLesions = sum(FROCGTList_local)
+    totalNumberOfLesions = sum(FROCGTList)
+    totalNumberOfCandidates = len(FROCProbList_local)
+    fpr, tpr, thresholds = skl_metrics.roc_curve(FROCGTList_local, FROCProbList_local)
+    if sum(FROCGTList) == len(
+        FROCGTList):  # Handle border case when there are no false positives and ROC analysis give nan values.
+        print("WARNING, this system has no false positives..")
+        fps = np.zeros(len(fpr))
+    else:
+        fps = fpr * (totalNumberOfCandidates - numberOfDetectedLesions) / totalNumberOfImages
+    sens = (tpr * numberOfDetectedLesions) / totalNumberOfLesions
+    return fps, sens, thresholds
+
+
+def evaluateCAD(seriesUIDs, results_filename, outputDir, allNodules, CADSystemName, maxNumberOfCADMarks=-1,
+                performBootstrapping=False, numberOfBootstrapSamples=1000, confidence=0.95):
+    '''
+    function to evaluate a CAD algorithm
+    @param seriesUIDs: list of the seriesUIDs of the cases to be processed
+    @param results_filename: file with results
+    @param outputDir: output directory
+    @param allNodules: dictionary with all nodule annotations of all cases, keys of the dictionary are the seriesuids
+    @param CADSystemName: name of the CAD system, to be used in filenames and on FROC curve
+    '''
+
+    nodOutputfile = open(os.path.join(outputDir, 'CADAnalysis.txt'), 'w')
+    nodOutputfile.write("\n")
+    nodOutputfile.write((60 * "*") + "\n")
+    nodOutputfile.write("CAD Analysis: %s\n" % CADSystemName)
+    nodOutputfile.write((60 * "*") + "\n")
+    nodOutputfile.write("\n")
+
+    results = csvTools.readCSV(results_filename)
+
+    allCandsCAD = {}
+
+    for seriesuid in seriesUIDs:
+
+        # collect candidates from result file
+        nodules = {}
+        header = results[0]
+
+        i = 0
+        for result in results[1:]:
+            nodule_seriesuid = result[header.index(seriesuid_label)]
+
+            if seriesuid == nodule_seriesuid:
+                nodule = getNodule(result, header)
+                nodule.candidateID = i
+                nodules[nodule.candidateID] = nodule
+                i += 1
+
+        if (maxNumberOfCADMarks > 0):
+            # number of CAD marks, only keep must suspicous marks
+
+            if len(nodules.keys()) > maxNumberOfCADMarks:
+                # make a list of all probabilities
+                probs = []
+                for keytemp, noduletemp in nodules.items():
+                    probs.append(float(noduletemp.CADprobability))
+                probs.sort(reverse=True)  # sort from large to small
+                probThreshold = probs[maxNumberOfCADMarks]
+                nodules2 = {}
+                nrNodules2 = 0
+                for keytemp, noduletemp in nodules.items():
+                    if nrNodules2 >= maxNumberOfCADMarks:
+                        break
+                    if float(noduletemp.CADprobability) > probThreshold:
+                        nodules2[keytemp] = noduletemp
+                        nrNodules2 += 1
+
+                nodules = nodules2
+
+        print('adding candidates: ' + seriesuid)
+        allCandsCAD[seriesuid] = nodules
+
+    # open output files
+    nodNoCandFile = open(os.path.join(outputDir, "nodulesWithoutCandidate_%s.txt" % CADSystemName), 'w')
+
+    # --- iterate over all cases (seriesUIDs) and determine how
+    # often a nodule annotation is not covered by a candidate
+
+    # initialize some variables to be used in the loop
+    candTPs = 0
+    candFPs = 0
+    candFNs = 0
+    candTNs = 0
+    totalNumberOfCands = 0
+    totalNumberOfNodules = 0
+    doubleCandidatesIgnored = 0
+    irrelevantCandidates = 0
+    minProbValue = -1000000000.0  # minimum value of a float
+    FROCGTList = []
+    FROCProbList = []
+    FPDivisorList = []
+    excludeList = []
+    FROCtoNoduleMap = []
+    ignoredCADMarksList = []
+
+    # -- loop over the cases
+    for seriesuid in seriesUIDs:
+        # get the candidates for this case
+        try:
+            candidates = allCandsCAD[seriesuid]
+        except KeyError:
+            candidates = {}
+
+        # add to the total number of candidates
+        totalNumberOfCands += len(candidates.keys())
+
+        # make a copy in which items will be deleted
+        candidates2 = candidates.copy()
+
+        # get the nodule annotations on this case
+        try:
+            noduleAnnots = allNodules[seriesuid]
+        except KeyError:
+            noduleAnnots = []
+
+        # - loop over the nodule annotations
+        for noduleAnnot in noduleAnnots:
+            # increment the number of nodules
+            if noduleAnnot.state == "Included":
+                totalNumberOfNodules += 1
+
+            x = float(noduleAnnot.coordX)
+            y = float(noduleAnnot.coordY)
+            z = float(noduleAnnot.coordZ)
+
+            # 2. Check if the nodule annotation is covered by a candidate
+            # A nodule is marked as detected when the center of mass of the candidate is within a distance R of
+            # the center of the nodule. In order to ensure that the CAD mark is displayed within the nodule on the
+            # CT scan, we set R to be the radius of the nodule size.
+            diameter = float(noduleAnnot.diameter_mm)
+            if diameter < 0.0:
+                diameter = 10.0
+            radiusSquared = pow((diameter / 2.0), 2.0)
+
+            found = False
+            noduleMatches = []
+            for key, candidate in candidates.items():
+                x2 = float(candidate.coordX)
+                y2 = float(candidate.coordY)
+                z2 = float(candidate.coordZ)
+                dist = math.pow(x - x2, 2.) + math.pow(y - y2, 2.) + math.pow(z - z2, 2.)
+                if dist < radiusSquared:
+                    if (noduleAnnot.state == "Included"):
+                        found = True
+                        noduleMatches.append(candidate)
+                        if key not in candidates2.keys():
+                            print(
+                                "This is strange: CAD mark %s detected two nodules! Check for overlapping nodule annotations, SeriesUID: %s, nodule Annot ID: %s" % (
+                                    str(candidate.id), seriesuid, str(noduleAnnot.id)))
+                        else:
+                            del candidates2[key]
+                    elif (noduleAnnot.state == "Excluded"):  # an excluded nodule
+                        if bOtherNodulesAsIrrelevant:  # delete marks on excluded nodules so they don't count as false positives
+                            if key in candidates2.keys():
+                                irrelevantCandidates += 1
+                                ignoredCADMarksList.append("%s,%s,%s,%s,%s,%s,%.9f" % (
+                                    seriesuid, -1, candidate.coordX, candidate.coordY, candidate.coordZ,
+                                    str(candidate.id),
+                                    float(candidate.CADprobability)))
+                                del candidates2[key]
+            if len(noduleMatches) > 1:  # double detection
+                doubleCandidatesIgnored += (len(noduleMatches) - 1)
+            if noduleAnnot.state == "Included":
+                # only include it for FROC analysis if it is included
+                # otherwise, the candidate will not be counted as FP, but ignored in the
+                # analysis since it has been deleted from the nodules2 vector of candidates
+                if found == True:
+                    # append the sample with the highest probability for the FROC analysis
+                    maxProb = None
+                    for idx in range(len(noduleMatches)):
+                        candidate = noduleMatches[idx]
+                        if (maxProb is None) or (float(candidate.CADprobability) > maxProb):
+                            maxProb = float(candidate.CADprobability)
+
+                    FROCGTList.append(1.0)
+                    FROCProbList.append(float(maxProb))
+                    FPDivisorList.append(seriesuid)
+                    excludeList.append(False)
+                    FROCtoNoduleMap.append("%s,%s,%s,%s,%s,%.9f,%s,%.9f" % (
+                        seriesuid, noduleAnnot.id, noduleAnnot.coordX, noduleAnnot.coordY, noduleAnnot.coordZ,
+                        float(noduleAnnot.diameter_mm), str(candidate.id), float(candidate.CADprobability)))
+                    candTPs += 1
+                else:
+                    candFNs += 1
+                    # append a positive sample with the lowest probability, such that this is added in the FROC analysis
+                    FROCGTList.append(1.0)
+                    FROCProbList.append(minProbValue)
+                    FPDivisorList.append(seriesuid)
+                    excludeList.append(True)
+                    FROCtoNoduleMap.append("%s,%s,%s,%s,%s,%.9f,%s,%s" % (
+                        seriesuid, noduleAnnot.id, noduleAnnot.coordX, noduleAnnot.coordY, noduleAnnot.coordZ,
+                        float(noduleAnnot.diameter_mm), int(-1), "NA"))
+                    nodNoCandFile.write("%s,%s,%s,%s,%s,%.9f,%s\n" % (
+                        seriesuid, noduleAnnot.id, noduleAnnot.coordX, noduleAnnot.coordY, noduleAnnot.coordZ,
+                        float(noduleAnnot.diameter_mm), str(-1)))
+
+        # add all false positives to the vectors
+        for key, candidate3 in candidates2.items():
+            candFPs += 1
+            FROCGTList.append(0.0)
+            FROCProbList.append(float(candidate3.CADprobability))
+            FPDivisorList.append(seriesuid)
+            excludeList.append(False)
+            FROCtoNoduleMap.append("%s,%s,%s,%s,%s,%s,%.9f" % (
+                seriesuid, -1, candidate3.coordX, candidate3.coordY, candidate3.coordZ, str(candidate3.id),
+                float(candidate3.CADprobability)))
+
+    if not (len(FROCGTList) == len(FROCProbList) and len(FROCGTList) == len(FPDivisorList) and len(FROCGTList) == len(
+        FROCtoNoduleMap) and len(FROCGTList) == len(excludeList)):
+        nodOutputfile.write("Length of FROC vectors not the same, this should never happen! Aborting..\n")
+
+    nodOutputfile.write("Candidate detection results:\n")
+    nodOutputfile.write("    True positives: %d\n" % candTPs)
+    nodOutputfile.write("    False positives: %d\n" % candFPs)
+    nodOutputfile.write("    False negatives: %d\n" % candFNs)
+    nodOutputfile.write("    True negatives: %d\n" % candTNs)
+    nodOutputfile.write("    Total number of candidates: %d\n" % totalNumberOfCands)
+    nodOutputfile.write("    Total number of nodules: %d\n" % totalNumberOfNodules)
+
+    nodOutputfile.write("    Ignored candidates on excluded nodules: %d\n" % irrelevantCandidates)
+    nodOutputfile.write(
+        "    Ignored candidates which were double detections on a nodule: %d\n" % doubleCandidatesIgnored)
+    if int(totalNumberOfNodules) == 0:
+        nodOutputfile.write("    Sensitivity: 0.0\n")
+    else:
+        nodOutputfile.write("    Sensitivity: %.9f\n" % (float(candTPs) / float(totalNumberOfNodules)))
+    nodOutputfile.write(
+        "    Average number of candidates per scan: %.9f\n" % (float(totalNumberOfCands) / float(len(seriesUIDs))))
+
+    # compute FROC
+    fps, sens, thresholds = computeFROC(FROCGTList, FROCProbList, len(seriesUIDs), excludeList)
+
+    if performBootstrapping:
+        fps_bs_itp, sens_bs_mean, sens_bs_lb, sens_bs_up = computeFROC_bootstrap(FROCGTList, FROCProbList,
+                                                                                 FPDivisorList, seriesUIDs, excludeList,
+                                                                                 numberOfBootstrapSamples=numberOfBootstrapSamples,
+                                                                                 confidence=confidence)
+
+    # Write FROC curve
+    with open(os.path.join(outputDir, "froc_%s.txt" % CADSystemName), 'w') as f:
+        for i in range(len(sens)):
+            f.write("%.9f,%.9f,%.9f\n" % (fps[i], sens[i], thresholds[i]))
+
+    # Write FROC vectors to disk as well
+    with open(os.path.join(outputDir, "froc_gt_prob_vectors_%s.csv" % CADSystemName), 'w') as f:
+        for i in range(len(FROCGTList)):
+            f.write("%d,%.9f\n" % (FROCGTList[i], FROCProbList[i]))
+
+    fps_itp = np.linspace(FROC_minX, FROC_maxX, num=10001)
+
+    sens_itp = np.interp(fps_itp, fps, sens)
+
+    if performBootstrapping:
+        # Write mean, lower, and upper bound curves to disk
+        with open(os.path.join(outputDir, "froc_%s_bootstrapping.csv" % CADSystemName), 'w') as f:
+            f.write("FPrate,Sensivity[Mean],Sensivity[Lower bound],Sensivity[Upper bound]\n")
+            for i in range(len(fps_bs_itp)):
+                f.write("%.9f,%.9f,%.9f,%.9f\n" % (fps_bs_itp[i], sens_bs_mean[i], sens_bs_lb[i], sens_bs_up[i]))
+    else:
+        fps_bs_itp = None
+        sens_bs_mean = None
+        sens_bs_lb = None
+        sens_bs_up = None
+
+    # create FROC graphs
+    if int(totalNumberOfNodules) > 0:
+        graphTitle = str("")
+        fig1 = plt.figure()
+        ax = plt.gca()
+        clr = 'b'
+        plt.plot(fps_itp, sens_itp, color=clr, label="%s" % CADSystemName, lw=2)
+        if performBootstrapping:
+            plt.plot(fps_bs_itp, sens_bs_mean, color=clr, ls='--')
+            plt.plot(fps_bs_itp, sens_bs_lb, color=clr, ls=':')  # , label = "lb")
+            plt.plot(fps_bs_itp, sens_bs_up, color=clr, ls=':')  # , label = "ub")
+            ax.fill_between(fps_bs_itp, sens_bs_lb, sens_bs_up, facecolor=clr, alpha=0.05)
+        xmin = FROC_minX
+        xmax = FROC_maxX
+        plt.xlim(xmin, xmax)
+        plt.ylim(0, 1)
+        plt.xlabel('Average number of false positives per scan')
+        plt.ylabel('Sensitivity')
+        plt.legend(loc='lower right')
+        plt.title('FROC performance - %s' % (CADSystemName))
+
+        if bLogPlot:
+            plt.xscale('log', basex=2)
+            ax.xaxis.set_major_formatter(FixedFormatter([0.125, 0.25, 0.5, 1, 2, 4, 8]))
+
+        # set your ticks manually
+        ax.xaxis.set_ticks([0.125, 0.25, 0.5, 1, 2, 4, 8])
+        ax.yaxis.set_ticks(np.arange(0, 1.1, 0.1))
+        plt.grid(b=True, which='both')
+        plt.tight_layout()
+
+        plt.savefig(os.path.join(outputDir, "froc_%s.png" % CADSystemName), bbox_inches=0, dpi=300)
+
+    return (fps, sens, thresholds, fps_bs_itp, sens_bs_mean, sens_bs_lb, sens_bs_up, fps_itp, sens_itp)
+
+
+def getNodule(annotation, header, state=""):
+    nodule = NoduleFinding()
+    nodule.coordX = annotation[header.index(coordX_label)]
+    nodule.coordY = annotation[header.index(coordY_label)]
+    nodule.coordZ = annotation[header.index(coordZ_label)]
+
+    if diameter_mm_label in header:
+        nodule.diameter_mm = annotation[header.index(diameter_mm_label)]
+
+    if CADProbability_label in header:
+        nodule.CADprobability = annotation[header.index(CADProbability_label)]
+
+    if not state == "":
+        nodule.state = state
+
+    return nodule
+
+
+def collectNoduleAnnotations(annotations, annotations_excluded, seriesUIDs):
+    allNodules = {}
+    noduleCount = 0
+    noduleCountTotal = 0
+
+    for seriesuid in seriesUIDs:
+        print('adding nodule annotations: ' + seriesuid)
+
+        nodules = []
+        numberOfIncludedNodules = 0
+
+        # add included findings
+        header = annotations[0]
+        for annotation in annotations[1:]:
+            nodule_seriesuid = annotation[header.index(seriesuid_label)]
+
+            if seriesuid == nodule_seriesuid:
+                nodule = getNodule(annotation, header, state="Included")
+                nodules.append(nodule)
+                numberOfIncludedNodules += 1
+
+        # add excluded findings
+        header = annotations_excluded[0]
+        for annotation in annotations_excluded[1:]:
+            nodule_seriesuid = annotation[header.index(seriesuid_label)]
+
+            if seriesuid == nodule_seriesuid:
+                nodule = getNodule(annotation, header, state="Excluded")
+                nodules.append(nodule)
+
+        allNodules[seriesuid] = nodules
+        noduleCount += numberOfIncludedNodules
+        noduleCountTotal += len(nodules)
+
+    print('Total number of included nodule annotations: ' + str(noduleCount))
+    print('Total number of nodule annotations: ' + str(noduleCountTotal))
+    return allNodules
+
+
+def collect(annotations_filename,
+            annotations_excluded_filename,
+            seriesuids_filename):
+    annotations = csvTools.readCSV(annotations_filename)
+    annotations_excluded = csvTools.readCSV(annotations_excluded_filename)
+    seriesUIDs_csv = csvTools.readCSV(seriesuids_filename)
+
+    seriesUIDs = []
+    for seriesUID in seriesUIDs_csv:
+        seriesUIDs.append(seriesUID[0])
+
+    allNodules = collectNoduleAnnotations(annotations,
+                                          annotations_excluded,
+                                          seriesUIDs)
+
+    return (allNodules, seriesUIDs)
+
+
+def noduleCADEvaluation(annotations_filename,
+                        annotations_excluded_filename,
+                        seriesuids_filename,
+                        results_filename,
+                        outputDir):
+    '''
+    function to load annotations and evaluate a CAD algorithm
+    @param annotations_filename: list of annotations
+    @param annotations_excluded_filename: list of annotations that are excluded from analysis
+    @param seriesuids_filename: list of CT images in seriesuids
+    @param results_filename: list of CAD marks with probabilities
+    @param outputDir: output directory
+    '''
+
+    print(annotations_filename)
+
+    (allNodules, seriesUIDs) = collect(annotations_filename,
+                                       annotations_excluded_filename,
+                                       seriesuids_filename)
+
+    return evaluateCAD(seriesUIDs, results_filename, outputDir, allNodules,
+                       os.path.splitext(os.path.basename(results_filename))[0],
+                       maxNumberOfCADMarks=100, performBootstrapping=bPerformBootstrapping,
+                       numberOfBootstrapSamples=bNumberOfBootstrapSamples, confidence=bConfidence)

--- a/prediction/src/evaluations/froc.py
+++ b/prediction/src/evaluations/froc.py
@@ -1,102 +1,26 @@
-import csv
 import math
 import os
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
+import scipy.spatial
 import sklearn.metrics as skl_metrics
-from NoduleFinding import NoduleFinding
 from matplotlib.ticker import FixedFormatter
-
-# Evaluation settings
-bPerformBootstrapping = True
-bNumberOfBootstrapSamples = 1000
-bOtherNodulesAsIrrelevant = True
-bConfidence = 0.95
-
-seriesuid_label = 'seriesuid'
-coordX_label = 'coordX'
-coordY_label = 'coordY'
-coordZ_label = 'coordZ'
-diameter_mm_label = 'diameter_mm'
-CADProbability_label = 'probability'
+from tqdm import tqdm
 
 # plot settings
-FROC_minX = 0.125  # Mininum value of x-axis of FROC curve
+FROC_minX = 0.125  # Minimum value of x-axis of FROC curve
 FROC_maxX = 8  # Maximum value of x-axis of FROC curve
-bLogPlot = True
-
-
-def writeCSV(filename, lines):
-    with open(filename, "w") as f:
-        csvwriter = csv.writer(f)
-        csvwriter.writerows(lines)
-
-
-def readCSV(filename):
-    lines = []
-    with open(filename, "r") as f:
-        csvreader = csv.reader(f)
-        for line in csvreader:
-            lines.append(line)
-    return lines
-
-
-def tryFloat(value):
-    try:
-        value = float(value)
-    except:
-        value = value
-
-    return value
-
-
-def getColumn(lines, columnid, elementType=''):
-    column = []
-    for line in lines:
-        try:
-            value = line[columnid]
-        except:
-            continue
-
-        if elementType == 'float':
-            value = tryFloat(value)
-
-        column.append(value)
-
-    return column
-
-
-class NoduleFinding(object):
-    '''
-    Represents a nodule
-    '''
-
-    def __init__(self, noduleid=None, coordX=None, coordY=None, coordZ=None, coordType="World",
-                 CADprobability=None, noduleType=None, diameter=None, state=None, seriesInstanceUID=None):
-        # set the variables and convert them to the correct type
-        self.id = noduleid
-        self.coordX = coordX
-        self.coordY = coordY
-        self.coordZ = coordZ
-        self.coordType = coordType
-        self.CADprobability = CADprobability
-        self.noduleType = noduleType
-        self.diameter_mm = diameter
-        self.state = state
-        self.candidateID = None
-        self.seriesuid = seriesInstanceUID
+cpm_xpoints = [0.125, 0.25, 0.5, 1, 2, 4, 8]
 
 
 def generateBootstrapSet(scanToCandidatesDict, FROCImList):
-    '''
-    Generates bootstrapped version of set
-    '''
-    imageLen = FROCImList.shape[0]
-
+    """
+    Generates bootstrapped version of set.
+    """
     # get a random list of images using sampling with replacement
-    rand_index_im = np.random.randint(imageLen, size=imageLen)
-    FROCImList_rand = FROCImList[rand_index_im]
+    FROCImList_rand = np.random.choice(FROCImList, size=len(FROCImList), replace=True)
 
     # get a new list of candidates
     candidatesExists = False
@@ -148,15 +72,14 @@ def computeFROC_bootstrap(FROCGTList, FROCProbList,
     scanToCandidatesDict = {}
     for i in range(len(FPDivisorList_np)):
         seriesuid = FPDivisorList_np[i]
-        candidate = set1[:, i:i + 1]
+        candidate = set1[:, i: i + 1]
 
         if seriesuid not in scanToCandidatesDict:
             scanToCandidatesDict[seriesuid] = np.copy(candidate)
         else:
             scanToCandidatesDict[seriesuid] = np.concatenate((scanToCandidatesDict[seriesuid], candidate), axis=1)
 
-    for i in range(numberOfBootstrapSamples):
-        print('computing FROC: bootstrap %d/%d' % (i, numberOfBootstrapSamples))
+    for i in tqdm(range(numberOfBootstrapSamples)):
         # Generate a bootstrapped set
         btpsamp = generateBootstrapSet(scanToCandidatesDict, FROCImList_np)
         fps, sens, thresholds = computeFROC(btpsamp[0, :], btpsamp[1, :], len(FROCImList_np), btpsamp[2, :])
@@ -184,17 +107,19 @@ def computeFROC(FROCGTList, FROCProbList,
     # Remove excluded candidates
     FROCGTList_local = []
     FROCProbList_local = []
+
     for i in range(len(excludeList)):
-        if excludeList[i] == False:
+        if not excludeList[i]:
             FROCGTList_local.append(FROCGTList[i])
             FROCProbList_local.append(FROCProbList[i])
 
     numberOfDetectedLesions = sum(FROCGTList_local)
     totalNumberOfLesions = sum(FROCGTList)
     totalNumberOfCandidates = len(FROCProbList_local)
+
     fpr, tpr, thresholds = skl_metrics.roc_curve(FROCGTList_local, FROCProbList_local)
-    if sum(FROCGTList) == len(
-        FROCGTList):  # Handle border case when there are no false positives and ROC analysis give nan values.
+    # Handle border case when there are no false positives and ROC analysis give nan values.
+    if sum(FROCGTList) == len(FROCGTList):
         print("WARNING, this system has no false positives..")
         fps = np.zeros(len(fpr))
     else:
@@ -203,268 +128,46 @@ def computeFROC(FROCGTList, FROCProbList,
     return fps, sens, thresholds
 
 
-def evaluateCAD(seriesUIDs, results_filename, outputDir, allNodules, CADSystemName, maxNumberOfCADMarks=-1,
-                performBootstrapping=False, numberOfBootstrapSamples=1000, confidence=0.95):
-    '''
-    function to evaluate a CAD algorithm
-    @param seriesUIDs: list of the seriesUIDs of the cases to be processed
-    @param results_filename: file with results
-    @param outputDir: output directory
-    @param allNodules: dictionary with all nodule annotations of all cases, keys of the dictionary are the seriesuids
-    @param CADSystemName: name of the CAD system, to be used in filenames and on FROC curve
-    '''
+def collect(annotations_filename,
+            annotations_excluded_filename,
+            seriesuids_filename,
+            results_filename):
+    annotations = pd.read_csv(annotations_filename)
+    annotations_excluded = pd.read_csv(annotations_excluded_filename)
+    seriesUIDs = pd.read_csv(seriesuids_filename, header=None, names=['seriesuid'])
 
-    nodOutputfile = open(os.path.join(outputDir, 'CADAnalysis.txt'), 'w')
-    nodOutputfile.write("\n")
-    nodOutputfile.write((60 * "*") + "\n")
-    nodOutputfile.write("CAD Analysis: %s\n" % CADSystemName)
-    nodOutputfile.write((60 * "*") + "\n")
-    nodOutputfile.write("\n")
+    # nodules = annotations.loc[annotations.seriesuid.isin(seriesUIDs.seriesuid)]
+    nodules = pd.merge(annotations, seriesUIDs, how='inner', on=['seriesuid'])
+    nodules['included'] = True
 
-    results = csvTools.readCSV(results_filename)
+    # nodules_excluded = annotations_excluded.loc[annotations_excluded.seriesuid.isin(seriesUIDs.seriesuid)]
+    nodules_excluded = pd.merge(annotations_excluded, seriesUIDs, how='inner', on=['seriesuid'])
+    nodules_excluded['included'] = False
+    allNodules = pd.concat([nodules, nodules_excluded])
+    allNodules.loc[allNodules.diameter_mm <= 0, 'diameter_mm'] = 10
 
-    allCandsCAD = {}
+    results = pd.read_csv(results_filename)
+    # results = results.loc[results.seriesuid.isin(seriesUIDs.seriesuid)]
+    results = pd.merge(results, seriesUIDs, how='inner', on=['seriesuid'])
 
-    for seriesuid in seriesUIDs:
+    return (allNodules, results, seriesUIDs)
 
-        # collect candidates from result file
-        nodules = {}
-        header = results[0]
 
-        i = 0
-        for result in results[1:]:
-            nodule_seriesuid = result[header.index(seriesuid_label)]
-
-            if seriesuid == nodule_seriesuid:
-                nodule = getNodule(result, header)
-                nodule.candidateID = i
-                nodules[nodule.candidateID] = nodule
-                i += 1
-
-        if (maxNumberOfCADMarks > 0):
-            # number of CAD marks, only keep must suspicous marks
-
-            if len(nodules.keys()) > maxNumberOfCADMarks:
-                # make a list of all probabilities
-                probs = []
-                for keytemp, noduletemp in nodules.items():
-                    probs.append(float(noduletemp.CADprobability))
-                probs.sort(reverse=True)  # sort from large to small
-                probThreshold = probs[maxNumberOfCADMarks]
-                nodules2 = {}
-                nrNodules2 = 0
-                for keytemp, noduletemp in nodules.items():
-                    if nrNodules2 >= maxNumberOfCADMarks:
-                        break
-                    if float(noduletemp.CADprobability) > probThreshold:
-                        nodules2[keytemp] = noduletemp
-                        nrNodules2 += 1
-
-                nodules = nodules2
-
-        print('adding candidates: ' + seriesuid)
-        allCandsCAD[seriesuid] = nodules
-
-    # open output files
-    nodNoCandFile = open(os.path.join(outputDir, "nodulesWithoutCandidate_%s.txt" % CADSystemName), 'w')
-
-    # --- iterate over all cases (seriesUIDs) and determine how
-    # often a nodule annotation is not covered by a candidate
-
-    # initialize some variables to be used in the loop
-    candTPs = 0
-    candFPs = 0
-    candFNs = 0
-    candTNs = 0
-    totalNumberOfCands = 0
-    totalNumberOfNodules = 0
-    doubleCandidatesIgnored = 0
-    irrelevantCandidates = 0
-    minProbValue = -1000000000.0  # minimum value of a float
-    FROCGTList = []
-    FROCProbList = []
-    FPDivisorList = []
-    excludeList = []
-    FROCtoNoduleMap = []
-    ignoredCADMarksList = []
-
-    # -- loop over the cases
-    for seriesuid in seriesUIDs:
-        # get the candidates for this case
-        try:
-            candidates = allCandsCAD[seriesuid]
-        except KeyError:
-            candidates = {}
-
-        # add to the total number of candidates
-        totalNumberOfCands += len(candidates.keys())
-
-        # make a copy in which items will be deleted
-        candidates2 = candidates.copy()
-
-        # get the nodule annotations on this case
-        try:
-            noduleAnnots = allNodules[seriesuid]
-        except KeyError:
-            noduleAnnots = []
-
-        # - loop over the nodule annotations
-        for noduleAnnot in noduleAnnots:
-            # increment the number of nodules
-            if noduleAnnot.state == "Included":
-                totalNumberOfNodules += 1
-
-            x = float(noduleAnnot.coordX)
-            y = float(noduleAnnot.coordY)
-            z = float(noduleAnnot.coordZ)
-
-            # 2. Check if the nodule annotation is covered by a candidate
-            # A nodule is marked as detected when the center of mass of the candidate is within a distance R of
-            # the center of the nodule. In order to ensure that the CAD mark is displayed within the nodule on the
-            # CT scan, we set R to be the radius of the nodule size.
-            diameter = float(noduleAnnot.diameter_mm)
-            if diameter < 0.0:
-                diameter = 10.0
-            radiusSquared = pow((diameter / 2.0), 2.0)
-
-            found = False
-            noduleMatches = []
-            for key, candidate in candidates.items():
-                x2 = float(candidate.coordX)
-                y2 = float(candidate.coordY)
-                z2 = float(candidate.coordZ)
-                dist = math.pow(x - x2, 2.) + math.pow(y - y2, 2.) + math.pow(z - z2, 2.)
-                if dist < radiusSquared:
-                    if (noduleAnnot.state == "Included"):
-                        found = True
-                        noduleMatches.append(candidate)
-                        if key not in candidates2.keys():
-                            print(
-                                "This is strange: CAD mark %s detected two nodules! Check for overlapping nodule annotations, SeriesUID: %s, nodule Annot ID: %s" % (
-                                    str(candidate.id), seriesuid, str(noduleAnnot.id)))
-                        else:
-                            del candidates2[key]
-                    elif (noduleAnnot.state == "Excluded"):  # an excluded nodule
-                        if bOtherNodulesAsIrrelevant:  # delete marks on excluded nodules so they don't count as false positives
-                            if key in candidates2.keys():
-                                irrelevantCandidates += 1
-                                ignoredCADMarksList.append("%s,%s,%s,%s,%s,%s,%.9f" % (
-                                    seriesuid, -1, candidate.coordX, candidate.coordY, candidate.coordZ,
-                                    str(candidate.id),
-                                    float(candidate.CADprobability)))
-                                del candidates2[key]
-            if len(noduleMatches) > 1:  # double detection
-                doubleCandidatesIgnored += (len(noduleMatches) - 1)
-            if noduleAnnot.state == "Included":
-                # only include it for FROC analysis if it is included
-                # otherwise, the candidate will not be counted as FP, but ignored in the
-                # analysis since it has been deleted from the nodules2 vector of candidates
-                if found == True:
-                    # append the sample with the highest probability for the FROC analysis
-                    maxProb = None
-                    for idx in range(len(noduleMatches)):
-                        candidate = noduleMatches[idx]
-                        if (maxProb is None) or (float(candidate.CADprobability) > maxProb):
-                            maxProb = float(candidate.CADprobability)
-
-                    FROCGTList.append(1.0)
-                    FROCProbList.append(float(maxProb))
-                    FPDivisorList.append(seriesuid)
-                    excludeList.append(False)
-                    FROCtoNoduleMap.append("%s,%s,%s,%s,%s,%.9f,%s,%.9f" % (
-                        seriesuid, noduleAnnot.id, noduleAnnot.coordX, noduleAnnot.coordY, noduleAnnot.coordZ,
-                        float(noduleAnnot.diameter_mm), str(candidate.id), float(candidate.CADprobability)))
-                    candTPs += 1
-                else:
-                    candFNs += 1
-                    # append a positive sample with the lowest probability, such that this is added in the FROC analysis
-                    FROCGTList.append(1.0)
-                    FROCProbList.append(minProbValue)
-                    FPDivisorList.append(seriesuid)
-                    excludeList.append(True)
-                    FROCtoNoduleMap.append("%s,%s,%s,%s,%s,%.9f,%s,%s" % (
-                        seriesuid, noduleAnnot.id, noduleAnnot.coordX, noduleAnnot.coordY, noduleAnnot.coordZ,
-                        float(noduleAnnot.diameter_mm), int(-1), "NA"))
-                    nodNoCandFile.write("%s,%s,%s,%s,%s,%.9f,%s\n" % (
-                        seriesuid, noduleAnnot.id, noduleAnnot.coordX, noduleAnnot.coordY, noduleAnnot.coordZ,
-                        float(noduleAnnot.diameter_mm), str(-1)))
-
-        # add all false positives to the vectors
-        for key, candidate3 in candidates2.items():
-            candFPs += 1
-            FROCGTList.append(0.0)
-            FROCProbList.append(float(candidate3.CADprobability))
-            FPDivisorList.append(seriesuid)
-            excludeList.append(False)
-            FROCtoNoduleMap.append("%s,%s,%s,%s,%s,%s,%.9f" % (
-                seriesuid, -1, candidate3.coordX, candidate3.coordY, candidate3.coordZ, str(candidate3.id),
-                float(candidate3.CADprobability)))
-
-    if not (len(FROCGTList) == len(FROCProbList) and len(FROCGTList) == len(FPDivisorList) and len(FROCGTList) == len(
-        FROCtoNoduleMap) and len(FROCGTList) == len(excludeList)):
-        nodOutputfile.write("Length of FROC vectors not the same, this should never happen! Aborting..\n")
-
-    nodOutputfile.write("Candidate detection results:\n")
-    nodOutputfile.write("    True positives: %d\n" % candTPs)
-    nodOutputfile.write("    False positives: %d\n" % candFPs)
-    nodOutputfile.write("    False negatives: %d\n" % candFNs)
-    nodOutputfile.write("    True negatives: %d\n" % candTNs)
-    nodOutputfile.write("    Total number of candidates: %d\n" % totalNumberOfCands)
-    nodOutputfile.write("    Total number of nodules: %d\n" % totalNumberOfNodules)
-
-    nodOutputfile.write("    Ignored candidates on excluded nodules: %d\n" % irrelevantCandidates)
-    nodOutputfile.write(
-        "    Ignored candidates which were double detections on a nodule: %d\n" % doubleCandidatesIgnored)
-    if int(totalNumberOfNodules) == 0:
-        nodOutputfile.write("    Sensitivity: 0.0\n")
-    else:
-        nodOutputfile.write("    Sensitivity: %.9f\n" % (float(candTPs) / float(totalNumberOfNodules)))
-    nodOutputfile.write(
-        "    Average number of candidates per scan: %.9f\n" % (float(totalNumberOfCands) / float(len(seriesUIDs))))
-
-    # compute FROC
-    fps, sens, thresholds = computeFROC(FROCGTList, FROCProbList, len(seriesUIDs), excludeList)
-
-    if performBootstrapping:
-        fps_bs_itp, sens_bs_mean, sens_bs_lb, sens_bs_up = computeFROC_bootstrap(FROCGTList, FROCProbList,
-                                                                                 FPDivisorList, seriesUIDs, excludeList,
-                                                                                 numberOfBootstrapSamples=numberOfBootstrapSamples,
-                                                                                 confidence=confidence)
-
-    # Write FROC curve
-    with open(os.path.join(outputDir, "froc_%s.txt" % CADSystemName), 'w') as f:
-        for i in range(len(sens)):
-            f.write("%.9f,%.9f,%.9f\n" % (fps[i], sens[i], thresholds[i]))
-
-    # Write FROC vectors to disk as well
-    with open(os.path.join(outputDir, "froc_gt_prob_vectors_%s.csv" % CADSystemName), 'w') as f:
-        for i in range(len(FROCGTList)):
-            f.write("%d,%.9f\n" % (FROCGTList[i], FROCProbList[i]))
-
+def make_plot(fps, sens, fps_bs_itp, sens_bs_mean, sens_bs_lb, sens_bs_up,
+              FROCProbList, numberOfBootstrapSamples, outputDir, CADSystemName):
+    """
+    Plot FROC graphs in log scale.
+    """
     fps_itp = np.linspace(FROC_minX, FROC_maxX, num=10001)
-
     sens_itp = np.interp(fps_itp, fps, sens)
 
-    if performBootstrapping:
-        # Write mean, lower, and upper bound curves to disk
-        with open(os.path.join(outputDir, "froc_%s_bootstrapping.csv" % CADSystemName), 'w') as f:
-            f.write("FPrate,Sensivity[Mean],Sensivity[Lower bound],Sensivity[Upper bound]\n")
-            for i in range(len(fps_bs_itp)):
-                f.write("%.9f,%.9f,%.9f,%.9f\n" % (fps_bs_itp[i], sens_bs_mean[i], sens_bs_lb[i], sens_bs_up[i]))
-    else:
-        fps_bs_itp = None
-        sens_bs_mean = None
-        sens_bs_lb = None
-        sens_bs_up = None
-
     # create FROC graphs
-    if int(totalNumberOfNodules) > 0:
-        graphTitle = str("")
-        fig1 = plt.figure()
+    if len(FROCProbList):
+        plt.figure()
         ax = plt.gca()
         clr = 'b'
         plt.plot(fps_itp, sens_itp, color=clr, label="%s" % CADSystemName, lw=2)
-        if performBootstrapping:
+        if numberOfBootstrapSamples:
             plt.plot(fps_bs_itp, sens_bs_mean, color=clr, ls='--')
             plt.plot(fps_bs_itp, sens_bs_lb, color=clr, ls=':')  # , label = "lb")
             plt.plot(fps_bs_itp, sens_bs_up, color=clr, ls=':')  # , label = "ub")
@@ -478,117 +181,124 @@ def evaluateCAD(seriesUIDs, results_filename, outputDir, allNodules, CADSystemNa
         plt.legend(loc='lower right')
         plt.title('FROC performance - %s' % (CADSystemName))
 
-        if bLogPlot:
-            plt.xscale('log', basex=2)
-            ax.xaxis.set_major_formatter(FixedFormatter([0.125, 0.25, 0.5, 1, 2, 4, 8]))
+        plt.xscale('log', basex=2)
+        ax.xaxis.set_major_formatter(FixedFormatter(cpm_xpoints))
 
         # set your ticks manually
-        ax.xaxis.set_ticks([0.125, 0.25, 0.5, 1, 2, 4, 8])
+        ax.xaxis.set_ticks(cpm_xpoints)
         ax.yaxis.set_ticks(np.arange(0, 1.1, 0.1))
         plt.grid(b=True, which='both')
         plt.tight_layout()
 
         plt.savefig(os.path.join(outputDir, "froc_%s.png" % CADSystemName), bbox_inches=0, dpi=300)
 
-    return (fps, sens, thresholds, fps_bs_itp, sens_bs_mean, sens_bs_lb, sens_bs_up, fps_itp, sens_itp)
 
+def competition_performance_metric(annotations_path, annotations_excluded_path,
+                                   seriesuids_path, results_path, output_dir, postfix='CAD',
+                                   nb_bootstrap=1000, max_nb_CAD_marks=100,
+                                   confidence=.95, plot=True):
+    """
+    Computes competition performance metric,
+    implementation based on https://luna16.grand-challenge.org/evaluation/
 
-def getNodule(annotation, header, state=""):
-    nodule = NoduleFinding()
-    nodule.coordX = annotation[header.index(coordX_label)]
-    nodule.coordY = annotation[header.index(coordY_label)]
-    nodule.coordZ = annotation[header.index(coordZ_label)]
+    Params:
+        annotations_path (str): path to annotations csv file, should contain following columns:
+            [seriesuid, coordX, coordY, coordZ, diameter_mm]
+        annotations_excluded_path (str): path to annotations excluded csv file, should contain following columns:
+            [seriesuid, coordX, coordY, coordZ, diameter_mm]
+        seriesuids_path (str): path to seriesuids csv file, should contain following columns:
+            [seriesuid]
+        results_path (str): path to results csv file, should contain following columns:
+            [seriesuid, coordX, coordY, coordZ, probability]
+        output_dir (str): directory for the output files.
+        postfix (str): a postfix to output files.
+        nb_bootstrap (int): number of bootstrap samples to be computed,
+            if False then no bootstrap will be applied.
+        max_nb_CAD_marks: maximum amount of registrations per scan (sorted by probabilities values)
+        confidence: value for symmetric confidence interval.
+        plot: whether to plot FROC graphs in log scale.
 
-    if diameter_mm_label in header:
-        nodule.diameter_mm = annotation[header.index(diameter_mm_label)]
+    Returns:
+        1-d array of CPM values.
+    """
+    nodules, results, series = collect(
+        annotations_path,
+        annotations_excluded_path,
+        seriesuids_path,
+        results_path
+    )
 
-    if CADProbability_label in header:
-        nodule.CADprobability = annotation[header.index(CADProbability_label)]
+    cand_TPs = cand_FPs = cand_FNs = 0
+    FROC_GTs = []
+    FROC_probs = []
+    FP_divisors = []
+    excludes = []
 
-    if not state == "":
-        nodule.state = state
+    all_candidates = results.groupby(['seriesuid']).groups
+    for seriesuid, candidates in all_candidates.items():
+        candidates = results.loc[candidates]
+        candidates = candidates.sort_values(
+            ['probability'],
+            ascending=False
+        ).iloc[:max_nb_CAD_marks]
 
-    return nodule
+        nodule_annots = nodules[nodules.seriesuid == seriesuid]
+        acoords = nodule_annots[['coordX', 'coordY', 'coordZ']].values
+        bcoords = candidates[['coordX', 'coordY', 'coordZ']].values
+        dists = scipy.spatial.distance.cdist(acoords, bcoords)
+        covered = dists <= np.expand_dims(nodule_annots.diameter_mm / 2, -1)
 
+        included = nodule_annots.included
 
-def collectNoduleAnnotations(annotations, annotations_excluded, seriesUIDs):
-    allNodules = {}
-    noduleCount = 0
-    noduleCountTotal = 0
+        pvals = [candidates.probability[c].max() for c in covered[nodule_annots.included]]
+        pvals = [p for p in pvals if not np.isnan(p)]
 
-    for seriesuid in seriesUIDs:
-        print('adding nodule annotations: ' + seriesuid)
+        FROC_probs.extend(pvals)
+        FROC_GTs.extend([1] * len(pvals))
+        FP_divisors.extend([seriesuid] * len(pvals))
+        excludes.extend([False] * len(pvals))
+        cand_TPs += len(pvals)
 
-        nodules = []
-        numberOfIncludedNodules = 0
+        uncovered = True ^ covered.sum(axis=-1, dtype=np.bool_)
+        uncovered_incl = (included & uncovered).sum()
 
-        # add included findings
-        header = annotations[0]
-        for annotation in annotations[1:]:
-            nodule_seriesuid = annotation[header.index(seriesuid_label)]
+        cand_FNs += uncovered_incl
+        # append a positive sample with the lowest probability, such that this is added in the FROC analysis
+        FROC_GTs.extend([1.] * uncovered_incl)
+        FROC_probs.extend([-1.] * uncovered_incl)
+        FP_divisors.extend([seriesuid] * uncovered_incl)
+        excludes.extend([True] * uncovered_incl)
 
-            if seriesuid == nodule_seriesuid:
-                nodule = getNodule(annotation, header, state="Included")
-                nodules.append(nodule)
-                numberOfIncludedNodules += 1
+        probs = candidates.probability[True ^ covered.sum(axis=0, dtype=np.bool_)]
+        cand_FPs += len(probs)
+        FROC_GTs.extend([0.] * len(probs))
+        FROC_probs.extend(probs.values.tolist())
+        FP_divisors.extend([seriesuid] * len(probs))
+        excludes.extend([False] * len(probs))
 
-        # add excluded findings
-        header = annotations_excluded[0]
-        for annotation in annotations_excluded[1:]:
-            nodule_seriesuid = annotation[header.index(seriesuid_label)]
+    predicat = len(FROC_GTs) == len(FROC_probs) == len(FP_divisors) == len(excludes)
+    assert predicat, "Length of FROC vectors not the same, this should never happen! Aborting..\n"
 
-            if seriesuid == nodule_seriesuid:
-                nodule = getNodule(annotation, header, state="Excluded")
-                nodules.append(nodule)
+    # compute FROC
+    fps, sens, thresholds = computeFROC(FROC_GTs, FROC_probs, len(series), excludes)
 
-        allNodules[seriesuid] = nodules
-        noduleCount += numberOfIncludedNodules
-        noduleCountTotal += len(nodules)
+    if nb_bootstrap:
+        fps_bs_itp, sens_bs_mean, sens_bs_lb, sens_bs_up = computeFROC_bootstrap(
+            FROC_GTs,
+            FROC_probs,
+            FP_divisors,
+            series.seriesuid,
+            excludes,
+            numberOfBootstrapSamples=nb_bootstrap,
+            confidence=confidence
+        )
+    else:
+        fps_bs_itp = sens_bs_mean = sens_bs_lb = sens_bs_up = None
 
-    print('Total number of included nodule annotations: ' + str(noduleCount))
-    print('Total number of nodule annotations: ' + str(noduleCountTotal))
-    return allNodules
+    if plot:
+        make_plot(fps, sens, fps_bs_itp, sens_bs_mean, sens_bs_lb, sens_bs_up,
+                  FROC_probs, nb_bootstrap, output_dir, postfix)
 
+    idxs = [min(np.where(fps >= p)[0]) for p in cpm_xpoints]
 
-def collect(annotations_filename,
-            annotations_excluded_filename,
-            seriesuids_filename):
-    annotations = csvTools.readCSV(annotations_filename)
-    annotations_excluded = csvTools.readCSV(annotations_excluded_filename)
-    seriesUIDs_csv = csvTools.readCSV(seriesuids_filename)
-
-    seriesUIDs = []
-    for seriesUID in seriesUIDs_csv:
-        seriesUIDs.append(seriesUID[0])
-
-    allNodules = collectNoduleAnnotations(annotations,
-                                          annotations_excluded,
-                                          seriesUIDs)
-
-    return (allNodules, seriesUIDs)
-
-
-def noduleCADEvaluation(annotations_filename,
-                        annotations_excluded_filename,
-                        seriesuids_filename,
-                        results_filename,
-                        outputDir):
-    '''
-    function to load annotations and evaluate a CAD algorithm
-    @param annotations_filename: list of annotations
-    @param annotations_excluded_filename: list of annotations that are excluded from analysis
-    @param seriesuids_filename: list of CT images in seriesuids
-    @param results_filename: list of CAD marks with probabilities
-    @param outputDir: output directory
-    '''
-
-    print(annotations_filename)
-
-    (allNodules, seriesUIDs) = collect(annotations_filename,
-                                       annotations_excluded_filename,
-                                       seriesuids_filename)
-
-    return evaluateCAD(seriesUIDs, results_filename, outputDir, allNodules,
-                       os.path.splitext(os.path.basename(results_filename))[0],
-                       maxNumberOfCADMarks=100, performBootstrapping=bPerformBootstrapping,
-                       numberOfBootstrapSamples=bNumberOfBootstrapSamples, confidence=bConfidence)
+    return sens[idxs]


### PR DESCRIPTION
This allows to compute [FROC](https://doi.org/10.1093/jicru/ndx009) and [CPM](https://doi.org/10.1109/TMI.2010.2072789) metrics with bootstrapping for the classification and detection tasks.

## Description
Free-Response Receiver Operating Characteristic ([FROC](https://doi.org/10.1093/jicru/ndx009)) and competition performance metric ([CPM](https://doi.org/10.1109/TMI.2010.2072789)). It computes an average of the seven sensitivities measured at several false positives per scan (FPPS) thresholds, more concretely, at each FPPS ∈ {0.125, 0.25, 0.5, 1, 2, 4, 8} true positive rate was computed. Mean of which forms the CPM as discussed in #271. 

## Reference to official issue
This reference to the #271.

## How Has This Been Tested?  
![froc_3dlrcnn](https://user-images.githubusercontent.com/9470024/35234253-c77195d4-ffa0-11e7-9bef-dd32c2a327fa.png)


[CPM](https://doi.org/10.1109/TMI.2010.2072789) over 10-Fold cross validation:

| 0.125 | 0.25 | 0.5 | 1 | 2 | 4 | 8 | Score ([CPM](https://doi.org/10.1109/TMI.2010.2072789)) |
|:-----:| ----- | ----- | ----- | ----- | ----- | ----- |:-----:|
| 0.595 | 0.670 | 0.731 |  0.793 |  0.835 | 0.868 | 0.887 | 0.76 |

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
