### PR TITLE
Reactivate tests and clear models

### DIFF
--- a/prediction/src/algorithms/classify/src/classification_model.py
+++ b/prediction/src/algorithms/classify/src/classification_model.py
@@ -117,3 +117,10 @@ class ClassificationModel(abc.ABC):
                                'p_concerning': float}}
         """
         pass
+
+    @abc.abstractmethod
+    def clear(self):
+        """
+        Clear all signs of backend models.
+        """
+        pass

--- a/prediction/src/algorithms/classify/src/lr3dcnn/model.py
+++ b/prediction/src/algorithms/classify/src/lr3dcnn/model.py
@@ -2,9 +2,10 @@ import keras
 import numpy as np
 import os
 from collections import defaultdict
+from keras import backend as K
+from src.algorithms.classify.src.classification_model import ClassificationModel
 from src.preprocess import preprocess_ct, load_ct, crop_patches, generators
 
-from src.algorithms.classify.src.classification_model import ClassificationModel
 from .architecture import net
 
 
@@ -307,3 +308,9 @@ class Model(ClassificationModel):
                 iter += 1
 
         return candidates
+
+    def clear(self):
+        del self.model
+        self.pull_ct.clear()
+        self.pull_patches.clear()
+        K.clear_session()

--- a/prediction/src/tests/test_classification.py
+++ b/prediction/src/tests/test_classification.py
@@ -1,15 +1,15 @@
 from ..algorithms.classify import trained_model
 
 
-# def test_classify_predict_load(metaimage_path, model_path):
-#     assert not trained_model.predict(metaimage_path, [], model_path)
-#
-#
-# def test_classify_dicom(dicom_paths, nodule_locations, model_path):
-#     predicted = trained_model.predict(dicom_paths[0], nodule_locations, model_path)
-#     assert predicted
-#     assert 0 <= predicted[0]['p_concerning'] <= 1
-#
+def test_classify_predict_load(metaimage_path, model_path):
+    assert not trained_model.predict(metaimage_path, [], model_path)
+
+
+def test_classify_dicom(dicom_paths, nodule_locations, model_path):
+    predicted = trained_model.predict(dicom_paths[0], nodule_locations, model_path)
+    assert predicted
+    assert 0 <= predicted[0]['p_concerning'] <= 1
+
 
 def test_classify_real_nodule_small_dicom(dicom_path_003, model_path):
     predicted = trained_model.predict(dicom_path_003, [{'x': 302, 'y': 287, 'z': 12}], model_path)

--- a/prediction/src/tests/test_classification_3dlrcnn.py
+++ b/prediction/src/tests/test_classification_3dlrcnn.py
@@ -1,5 +1,6 @@
-from ..algorithms.classify.src.lr3dcnn.model import Model
 import os
+
+from ..algorithms.classify.src.lr3dcnn.model import Model
 
 
 def test_classify_init_load(models_dir_path):
@@ -12,6 +13,7 @@ def test_classify_init_load(models_dir_path):
         data_format=None
     )
     assert model is not None
+    model.clear()
 
 
 def test_classify_predict(dicom_paths, nodule_locations, models_dir_path):
@@ -24,6 +26,7 @@ def test_classify_predict(dicom_paths, nodule_locations, models_dir_path):
     candidates = [{'file_path': dicom_paths[0], 'centroids': [nl for nl in nodule_locations]}]
     predicted = model.predict(candidates)
     assert 0 <= predicted[0]['centroids'][0]['p_concerning'] <= 1
+    model.clear()
 
 
 def test_classify_real_nodule_full_dicom(dicom_paths, models_dir_path):
@@ -37,3 +40,4 @@ def test_classify_real_nodule_full_dicom(dicom_paths, models_dir_path):
     predicted = model.predict(candidates)
     print(predicted)
     assert .3 <= predicted[0]['centroids'][0]['p_concerning'] <= 1
+    model.clear()


### PR DESCRIPTION
Refactoring of [`evaluate_detection.py`](https://github.com/concept-to-clinic/concept-to-clinic/compare/master...vessemer:refactoring?expand=1#diff-4764e224c7f674ff2dc226aeafcfedb9) and uncommented tests in [`test_classification.py`](https://github.com/concept-to-clinic/concept-to-clinic/compare/master...vessemer:refactoring?expand=1#diff-923cd917610b38983b2ce7907638acc4), as was mentioned in [this](https://github.com/concept-to-clinic/concept-to-clinic/pull/298#pullrequestreview-92612801) comment. Remove redundant [`self.scale_factor`](https://github.com/concept-to-clinic/concept-to-clinic/pull/304/files#diff-7ebde87c389dab64f0c9e8a81e6b6391L40) which is neither dependend on DATA_SHAPE nor on [`self.input_shape`](https://github.com/concept-to-clinic/concept-to-clinic/pull/304/files#diff-7ebde87c389dab64f0c9e8a81e6b6391L39) by [this](https://github.com/vessemer/concept-to-clinic/blame/e4ba764af6c6cb570fdb86efc2632eb59cbf7008/prediction/src/algorithms/segment/src/models/simple_3d_model.py#L64-L73) and [this](https://github.com/vessemer/concept-to-clinic/blame/e4ba764af6c6cb570fdb86efc2632eb59cbf7008/prediction/src/algorithms/segment/src/models/simple_3d_model.py#L48-L55). Remove redundant [`self.scale_factor`](https://github.com/concept-to-clinic/concept-to-clinic/pull/304/files#diff-7ebde87c389dab64f0c9e8a81e6b6391L40) which was neither dependend on DATA_SHAPE nor on [`self.input_shape`](https://github.com/concept-to-clinic/concept-to-clinic/pull/304/files#diff-7ebde87c389dab64f0c9e8a81e6b6391L39) by [this](https://github.com/vessemer/concept-to-clinic/blame/e4ba764af6c6cb570fdb86efc2632eb59cbf7008/prediction/src/algorithms/segment/src/models/simple_3d_model.py#L64-L73) and [this](https://github.com/vessemer/concept-to-clinic/blame/e4ba764af6c6cb570fdb86efc2632eb59cbf7008/prediction/src/algorithms/segment/src/models/simple_3d_model.py#L48-L55).

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
