### PR TITLE
Fix memory and styling errors

### DIFF
--- a/prediction/src/algorithms/evaluation/evaluate_detection.py
+++ b/prediction/src/algorithms/evaluation/evaluate_detection.py
@@ -230,7 +230,7 @@ def filter_detections(prediction, detection):
 # id,confidence,z,y,x,size
 # note: z index starts from 1 and unit of y, x, and size is px
 # output details in
-# ['Dataset', 'Patient', 'StudyInstanceUID', 'SeriesInstanceUID', 'Cancer (%)', 
+# ['Dataset', 'Patient', 'StudyInstanceUID', 'SeriesInstanceUID', 'Cancer (%)',
 # 'Confidence', 'ImageNo','CenterX (px)','CenterY (px)','Diameter (mm)']
 
 
@@ -243,7 +243,7 @@ def get_detection_detail(prediction, detection, filepaths):
         spacing = np.load(os.path.join(prep_result_path, id + '_info.npy'))[1]
         rows, cols = np.where(filepaths == id)
         if rows.size == 0:
-            print id, 'not found'
+            print(id, 'not found')
             continue
         probability = round(get_prediction_probability(prediction, id) * 100, 2)
         filepath = filepaths[rows][0]
@@ -295,7 +295,7 @@ detection = df.as_matrix()
 if os.path.exists(filepath):
     filepaths = np.load(filepath)
     detection_detail = get_detection_detail(prediction, detection, filepaths)
-    print detection_detail
+    print(detection_detail)
     df = pandas.DataFrame(detection_detail)
     df.columns = [
         'Dataset',
@@ -311,13 +311,13 @@ if os.path.exists(filepath):
     df.to_csv(detection_detail_file, index=False)
 
 detections = filter_detections(prediction, detection)
-print 'number of detections:', len(detections)
+print('number of detections:', len(detections))
 
 annotations = load_annotations_OsiriX(annotation_path)
-print 'number of annotations:', len(annotations)
+print('number of annotations:', len(annotations))
 
 correct_detection = compare_results(detections, annotations)
-print 'number of correct_detection:', correct_detection
+print('number of correct_detection:', correct_detection)
 
 # calculate precision rate
 if len(detections) == 0:
@@ -337,6 +337,6 @@ if precision == 0 and recall == 0:
 else:
     fscore = 2 * precision * recall / (precision + recall)
 
-print 'precision rate:', correct_detection, '/', len(detections), '(', round(precision, 2), '% )'
-print 'recall rate:', correct_detection, '/', len(annotations), '(', round(recall, 2), '% )'
-print 'f-score:', round(fscore, 2), '%'
+print('precision rate:', correct_detection, '/', len(detections), '(', round(precision, 2), '% )')
+print('recall rate:', correct_detection, '/', len(annotations), '(', round(recall, 2), '% )')
+print('f-score:', round(fscore, 2), '%')

--- a/prediction/src/preprocess/lung_segmentation.py
+++ b/prediction/src/preprocess/lung_segmentation.py
@@ -18,7 +18,10 @@ try:
 except ValueError:
     from config import Config
 
-DATA_SHAPE = (512, 512, 1024, 1)
+# P{|282 - h| <= 66} ~= 0.997, according to the Table 2 from the research paper, DOI10.1097/HP.0b013e31823a13f1
+# Taking into an account the spacing on z-axis >= 0.9
+# (282 + 66) / 0.9 = 386 voxels. Therefore, 512 voxels for z-axis should be enough for all cases.
+DATA_SHAPE = (512, 512, 512, 1)
 
 
 def get_z_range(dicom_path):

--- a/prediction/src/tests/test_volume_calculation.py
+++ b/prediction/src/tests/test_volume_calculation.py
@@ -8,8 +8,8 @@ from ..algorithms.segment.trained_model import calculate_volume
 def centroids(scope='session'):
     yield [
         {'x': 0, 'y': 0, 'z': 0},
-        {'x': 32, 'y': 32, 'z': 28},
-        {'x': 45, 'y': 45, 'z': 12}]
+        {'x': 28, 'y': 32, 'z': 32},
+        {'x': 12, 'y': 45, 'z': 45}]
 
 
 @pytest.fixture
@@ -17,7 +17,15 @@ def centroids_alt(scope='session'):
     yield [
         {'x': 0, 'y': 0, 'z': 0},
         {'x': 0, 'y': 0, 'z': 0},
-        {'x': 45, 'y': 45, 'z': 12}]
+        {'x': 12, 'y': 45, 'z': 45}]
+
+
+@pytest.fixture
+def centroids_clt(scope='session'):
+    yield [
+        {'x': 0, 'y': 0, 'z': 0},
+        {'x': 0, 'y': 0, 'z': 0},
+        {'x': 8.3, 'y': 31.5, 'z': 113}]
 
 
 @pytest.fixture
@@ -40,7 +48,7 @@ def generate_mask(centroids, volumes, shape=(50, 50, 29)):
     mask = np.zeros(shape, dtype=np.bool_)
 
     for centroid, volume in zip(centroids, volumes):
-        centroid_ = np.asarray([centroid['x'], centroid['y'], centroid['z']])
+        centroid_ = np.asarray([centroid['z'], centroid['y'], centroid['x']])
         free_voxels = np.where(mask != -1)
         free_voxels = np.asarray(free_voxels).T
         free_voxels = sorted(free_voxels, key=lambda x: np.linalg.norm(x - centroid_, ord=2))
@@ -78,14 +86,14 @@ def test_overlapped_volume_calculation(tmpdir, centroids_alt, volumes_alt):
     assert calculated_volumes == volumes_alt
 
 
-def test_overlapped_dicom_volume_calculation(tmpdir, dicom_path, centroids_alt, volumes_alt):
+def test_overlapped_dicom_volume_calculation(tmpdir, dicom_path, centroids_alt, centroids_clt, volumes_alt):
     mask = generate_mask(centroids_alt, volumes_alt)
 
     # The balls area must be 100 + 30, since first ball have overlapped with the second one
     assert mask.sum() == 130
 
     path = get_mask_path(tmpdir, mask)
-    calculated_volumes = calculate_volume(str(path), centroids_alt, dicom_path)
+    calculated_volumes = calculate_volume(str(path), centroids_clt, dicom_path)
 
     # Despite they are overlapped, the amount of volumes must have preserved
     assert len(calculated_volumes) == len(volumes_alt)


### PR DESCRIPTION
Previous behaviour leads to various `memory error`s. It happened time to time 'cause of unreasonably large choice of the [`DATA_SHAPE`](https://github.com/concept-to-clinic/concept-to-clinic/commit/06117fb72b1bf03ad8b522d2f9e42af1b6711a2c#diff-638bbca55ea01b2d5eeb28b7e52321eeR21). The average maximum height of lungs for a grown man, according to [this research](https://www.researchgate.net/profile/Kevin_Capello/publication/221873867_Linear_dimensions_and_volumes_of_human_lungs_obtained_from_CT_images/links/5a1d79daaca2726120b2c4b5/Linear-dimensions-and-volumes-of-human-lungs-obtained-from-CT-images.pdf) (Table 2), is 282mm with std equals to 22mm and median 274mm (Table 2). Assuming normal distribution, [3 sigmas](https://en.wikipedia.org/wiki/68%E2%80%9395%E2%80%9399.7_rule) aside the mean will lead to the probability of case `h` belong to the interval `P{|282 - h| <= 66} ~= 0.9974`. Taking into an account the fact that all algorithms which were described (not only implemented ones) works with spacing on z-axis >= 0.9, therefore, having an upper bound value of `(282 + 66) / 0.9 = 386` (voxels) for z-axis should be enough for all cases.

I've made `DATA_SHAPE` to be `(512, 512, 512)` which should fit in memory while having reserved space for the z-axis. 

## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
