### PR TITLE
Allows to calculate_volume in mm

### DIFF
--- a/prediction/src/tests/test_volume_calculation.py
+++ b/prediction/src/tests/test_volume_calculation.py
@@ -8,8 +8,8 @@ from ..algorithms.segment.trained_model import calculate_volume
 def centroids(scope='session'):
     yield [
         {'x': 0, 'y': 0, 'z': 0},
-        {'x': 32, 'y': 32, 'z': 28},
-        {'x': 45, 'y': 45, 'z': 12}]
+        {'x': 28, 'y': 32, 'z': 32},
+        {'x': 12, 'y': 45, 'z': 45}]
 
 
 @pytest.fixture
@@ -17,7 +17,15 @@ def centroids_alt(scope='session'):
     yield [
         {'x': 0, 'y': 0, 'z': 0},
         {'x': 0, 'y': 0, 'z': 0},
-        {'x': 45, 'y': 45, 'z': 12}]
+        {'x': 12, 'y': 45, 'z': 45}]
+
+
+@pytest.fixture
+def centroids_clt(scope='session'):
+    yield [
+        {'x': 0, 'y': 0, 'z': 0},
+        {'x': 0, 'y': 0, 'z': 0},
+        {'x': 8.3, 'y': 31.5, 'z': 113}]
 
 
 @pytest.fixture
@@ -40,7 +48,7 @@ def generate_mask(centroids, volumes, shape=(50, 50, 29)):
     mask = np.zeros(shape, dtype=np.bool_)
 
     for centroid, volume in zip(centroids, volumes):
-        centroid_ = np.asarray([centroid['x'], centroid['y'], centroid['z']])
+        centroid_ = np.asarray([centroid['z'], centroid['y'], centroid['x']])
         free_voxels = np.where(mask != -1)
         free_voxels = np.asarray(free_voxels).T
         free_voxels = sorted(free_voxels, key=lambda x: np.linalg.norm(x - centroid_, ord=2))
@@ -78,14 +86,14 @@ def test_overlapped_volume_calculation(tmpdir, centroids_alt, volumes_alt):
     assert calculated_volumes == volumes_alt
 
 
-def test_overlapped_dicom_volume_calculation(tmpdir, dicom_path, centroids_alt, volumes_alt):
+def test_overlapped_dicom_volume_calculation(tmpdir, dicom_path, centroids_alt, centroids_clt, volumes_alt):
     mask = generate_mask(centroids_alt, volumes_alt)
 
     # The balls area must be 100 + 30, since first ball have overlapped with the second one
     assert mask.sum() == 130
 
     path = get_mask_path(tmpdir, mask)
-    calculated_volumes = calculate_volume(str(path), centroids_alt, dicom_path)
+    calculated_volumes = calculate_volume(str(path), centroids_clt, dicom_path)
 
     # Despite they are overlapped, the amount of volumes must have preserved
     assert len(calculated_volumes) == len(volumes_alt)


### PR DESCRIPTION
[calculate_volume](https://github.com/concept-to-clinic/concept-to-clinic/pull/304/files#diff-d685e97b90047b1be62100544969f8ac) function now accept centroids in real-world units (mm) if meta was provided, which is logical and also leads to renewal of the [tests](https://github.com/concept-to-clinic/concept-to-clinic/compare/master...vessemer:calculate_volume?expand=1#diff-4dac9e3a237cb8ddd0ca837da32061ce)

The swap in tests is due to the `xyz` way to store volumetric data pushed by the PR #44.  

## CLA
- [X] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
