### PR TITLE
Build was failing at step 5/21 with code 1.

### DIFF
--- a/compose/base/Dockerfile-dev
+++ b/compose/base/Dockerfile-dev
@@ -1,6 +1,6 @@
 FROM ubuntu:rolling
 ENV PYTHONUNBUFFERED 1
-RUN apt-get update && apt-get install -y tcl tk python3.6 python3.6-tk wget python-opencv
+RUN apt-get update && apt-get install -y tcl tk python3.6 python3.6-tk wget python-opencv python3-distutils
 RUN wget https://bootstrap.pypa.io/get-pip.py
 RUN python3.6 get-pip.py
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Just added `python3-distutils` in the installation packages because of a new requirement of Ubuntu 18.04

## Reference to official issue

https://github.com/concept-to-clinic/concept-to-clinic/issues/312: 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`python3-pip` now requires `python3-distutils` or else it exits with an error.
**Without this change the build fails.**
<!--- If adding a new feature or making improvements not already reflected in an official issue, please reference the relevant sections of the design doc -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
After the change the stack has been built successfully.
<!--- Include details of your testing environment, and the tests you ran to -->
My test environment is Win10 Pro 1803 64Bit with Docker v.18.03.1-ce-win65 (17513) stable.
<!--- see how your change affects other areas of the code, etc. -->
This should affect all platforms.


## CLA
- [x] I have signed the CLA; if other committers are in the commit history, they have signed the CLA as well
